### PR TITLE
feat(baseos): add chezmoi install playbook

### DIFF
--- a/collections/baseos/developer.yaml
+++ b/collections/baseos/developer.yaml
@@ -350,6 +350,40 @@ playbooks:
               msg: "Claude Code installed: {{ claude_version.stdout }}"
             when: claude_version.stdout is defined
 
+  - name: chezmoi
+    play: |
+      ---
+      - name: Install chezmoi
+        hosts: "{{ target_host | default('all') }}"
+        become: true
+        gather_facts: true
+
+        vars:
+          chezmoi_install_script: "https://get.chezmoi.io"
+          chezmoi_bin_dir: "/usr/local/bin"
+
+        tasks:
+          - name: Ensure curl is installed
+            ansible.builtin.package:
+              name: curl
+              state: present
+
+          - name: Install chezmoi via one-line binary installer
+            ansible.builtin.shell:
+              cmd: sh -c "$(curl -fsLS {{ chezmoi_install_script }})" -- -b {{ chezmoi_bin_dir }}
+            args:
+              creates: "{{ chezmoi_bin_dir }}/chezmoi"
+
+          - name: Verify chezmoi installation
+            ansible.builtin.command:
+              cmd: "{{ chezmoi_bin_dir }}/chezmoi --version"
+            register: chezmoi_version
+            changed_when: false
+
+          - name: Show installed version
+            ansible.builtin.debug:
+              msg: "chezmoi installed: {{ chezmoi_version.stdout }}"
+
 vars:
   - name: dev-vars
     file: |


### PR DESCRIPTION
## Summary
- Adds a new `chezmoi` playbook to the `sthings.baseos` collection (in `collections/baseos/developer.yaml`)
- Uses the official one-line binary installer from https://get.chezmoi.io
- Installs the binary to `/usr/local/bin` and verifies the installation

## Details
The playbook follows the same pattern used for `claude_code`:
1. Ensures `curl` is installed
2. Runs `sh -c "$(curl -fsLS https://get.chezmoi.io)" -- -b /usr/local/bin` (idempotent via `creates:`)
3. Verifies install by running `chezmoi --version`
4. Prints the installed version via debug

Invoke with: `ansible-playbook sthings.baseos.chezmoi`

## Test plan
- [ ] Build collection: `task build-collection`
- [ ] Run playbook against a target host and confirm `/usr/local/bin/chezmoi` exists
- [ ] Re-run playbook and confirm task is skipped (idempotency)