### PR TITLE
feat(rke): update collection to deploy-configure-rke 2026.06.07 + fix k3s play bugs

### DIFF
--- a/collections/rke/README.md
+++ b/collections/rke/README.md
@@ -26,8 +26,8 @@ ansible-galaxy collection install https://github.com/stuttgart-things/ansible/re
 
 | Playbook | Description |
 |----------|-------------|
-| `sthings.rke.rke2` | Deploy multi-node RKE2 cluster (default k8s v1.33.4) with Cilium, registry mirrors, and LB IP pool |
-| `sthings.rke.rke2_cluster` | Deploy single-node RKE2 cluster (default k8s v1.35.1) with airgapped installation |
+| `sthings.rke.rke2` | Deploy multi-node RKE2 cluster (default k8s v1.36.1) with Cilium, registry mirrors, and LB IP pool |
+| `sthings.rke.rke2_cluster` | Deploy single-node RKE2 cluster (default k8s v1.36.1) with airgapped installation |
 | `sthings.rke.rke2_workflow` | General RKE2 deployment workflow using vars file |
 | `sthings.rke.upload_kubeconfig_vault` | Fetch kubeconfig from cluster and upload to HashiCorp Vault |
 | `sthings.rke.api_token` | Create Rancher API tokens with configurable TTL |
@@ -46,8 +46,8 @@ ansible-galaxy collection install https://github.com/stuttgart-things/ansible/re
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `rke_state` | `present` | Set to `absent` to destroy the cluster |
-| `rke2_k8s_version` | `1.33.4` | Kubernetes version |
-| `rke2_release_kind` | `rke2r1` | Release kind (rke2r1 or rke2r2) |
+| `rke2_k8s_version` | `1.36.1` | Kubernetes version |
+| `rke2_release_kind` | `rke2r2` | Release kind (rke2r1 or rke2r2) |
 | `cluster_setup` | `multinode` | Cluster mode: `singlenode` or `multinode` |
 | `rke2_airgapped_installation` | `true` | Enable airgapped installation |
 | `install_cilium` | `true` | Install Cilium CNI |
@@ -115,8 +115,8 @@ mkdir -p /home/sthings/.kube/
 ansible-playbook sthings.rke.rke2 \
 -i rke2 \
 -e rke2_fetched_kubeconfig_path=/home/sthings/.kube/${CLUSTER_NAME} \
--e rke2_k8s_version=1.33.4 \
--e rke2_release_kind=rke2r1 \
+-e rke2_k8s_version=1.36.1 \
+-e rke2_release_kind=rke2r2 \
 -vv
 
 # TEST CLUSTER CONNECTION

--- a/collections/rke/README.md
+++ b/collections/rke/README.md
@@ -15,9 +15,9 @@ ansible-galaxy collection install https://github.com/stuttgart-things/ansible/re
 
 | Role | Version | Description |
 |------|---------|-------------|
-| deploy-configure-rke | 2026.02.16-2 | Main RKE/K3s deployment orchestration |
+| deploy-configure-rke | 2026.06.07 | Main RKE/K3s deployment orchestration |
 | configure-rke-node | 2025.12.13 | Node configuration |
-| install-requirements | 2025.12.12 | Prerequisites installation |
+| install-requirements | 2026.04.13 | Prerequisites installation |
 | download-install-binary | 2025.03.27 | Binary download utilities |
 
 ## PLAYBOOKS
@@ -36,7 +36,7 @@ ansible-galaxy collection install https://github.com/stuttgart-things/ansible/re
 
 | Playbook | Description |
 |----------|-------------|
-| `sthings.rke.k3s` | Deploy single-node K3s cluster (default k8s v1.35.1) with Cilium, ingress-nginx (v4.14.1), cert-manager (v1.19.1), and LB IP pool |
+| `sthings.rke.k3s` | Deploy single-node K3s cluster (default k8s v1.36.1) with Cilium, ingress-nginx (v4.14.1), cert-manager (v1.19.1), and LB IP pool |
 | `sthings.rke.k3s_cluster` | Deploy single-node K3s cluster (minimal, fetches kubeconfig) |
 
 ## KEY VARIABLES
@@ -64,7 +64,7 @@ ansible-galaxy collection install https://github.com/stuttgart-things/ansible/re
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `k3s_state` | `present` | Set to `absent` to destroy the cluster |
-| `k3s_k8s_version` | `1.35.1` | Kubernetes version |
+| `k3s_k8s_version` | `1.36.1` | Kubernetes version |
 | `k3s_release_kind` | `k3s1` | Release kind |
 | `cluster_setup` | `singlenode` | Cluster mode |
 | `deploy_helm_charts` | `true` | Deploy ingress-nginx and cert-manager |
@@ -186,7 +186,7 @@ mkdir -p /home/sthings/.kube/
 # CHECK FOR K3s RELEASES: https://github.com/k3s-io/k3s/releases
 
 ansible-playbook sthings.rke.k3s \
--e k3s_k8s_version=1.35.1 \
+-e k3s_k8s_version=1.36.1 \
 -i k3s \
 -e cilium_lbrange_start_ip=192.168.5.10 \
 -e cilium_lbrange_stop_ip=192.168.5.20 \

--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -5,13 +5,13 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/deploy-configure-rke.git
       scm: git
-      version: 2026.02.16-2
+      version: 2026.06.07
     - src: https://github.com/stuttgart-things/configure-rke-node.git
       scm: git
       version: 2025.12.13
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
-      version: 2025.12.12
+      version: 2026.04.13
     - src: https://github.com/stuttgart-things/download-install-binary.git
       scm: git
       version: 2025.03.27

--- a/collections/rke/k3s.yaml
+++ b/collections/rke/k3s.yaml
@@ -24,6 +24,31 @@ playbooks:
           cluster_setup: singlenode
           install_cilium: true
 
+          # === optional new k3s features (uncomment to enable) ==============
+          # air-gapped IMAGES from a mirror (images-only; binary/script upstream):
+          # k3s_airgapped_installation: true
+          # k3s_airgapped_image_url: "https://your-mirror/k3s-airgap-images-amd64.tar.zst"
+          # k3s_airgapped_checksum: "sha256:..."          # optional integrity check
+          # fully-offline binary (stage k3s binary + INSTALL_K3S_SKIP_DOWNLOAD):
+          # k3s_airgapped_skip_download: true
+          # k3s_airgapped_binary_url: "https://your-mirror/k3s"
+          # k3s_installscript_url: "https://your-mirror/k3s-install.sh"   # zero egress
+          # registry pull-through mirror (writes /etc/rancher/k3s/registries.yaml):
+          # k3s_registry_mirrors:
+          #   - name: "docker.io"
+          #     endpoints:
+          #       - "https://docker.harbor.example.com"
+          #       - "https://registry-1.docker.io"        # upstream fallback
+          # k3s_registry_configs:                          # optional per-host auth/TLS
+          #   "docker.harbor.example.com":
+          #     username: "robot-puller"
+          #     password: "<robot-token>"
+          #     tls:
+          #       insecure_skip_verify: false
+          # SELinux toggles (enforcing RHEL-family air-gap):
+          # k3s_skip_selinux_rpm: true   # don't fetch k3s-selinux from a repo
+          # k3s_selinux_warn: true       # missing SELinux policy -> warn, not fatal
+
         roles:
           - role: sthings.rke.deploy_configure_rke
 
@@ -49,6 +74,32 @@ playbooks:
           cluster_setup: singlenode
           install_helm_diff: true
           install_cilium: true
+
+          # === optional new k3s features (uncomment to enable) ==============
+          # air-gapped IMAGES from a mirror (images-only; binary/script upstream):
+          # k3s_airgapped_installation: true
+          # k3s_airgapped_image_url: "https://your-mirror/k3s-airgap-images-amd64.tar.zst"
+          # k3s_airgapped_checksum: "sha256:..."          # optional integrity check
+          # fully-offline binary (stage k3s binary + INSTALL_K3S_SKIP_DOWNLOAD):
+          # k3s_airgapped_skip_download: true
+          # k3s_airgapped_binary_url: "https://your-mirror/k3s"
+          # k3s_installscript_url: "https://your-mirror/k3s-install.sh"   # zero egress
+          # registry pull-through mirror (writes /etc/rancher/k3s/registries.yaml):
+          # k3s_registry_mirrors:
+          #   - name: "docker.io"
+          #     endpoints:
+          #       - "https://docker.harbor.example.com"
+          #       - "https://registry-1.docker.io"        # upstream fallback
+          # k3s_registry_configs:                          # optional per-host auth/TLS
+          #   "docker.harbor.example.com":
+          #     username: "robot-puller"
+          #     password: "<robot-token>"
+          #     tls:
+          #       insecure_skip_verify: false
+          # SELinux toggles (enforcing RHEL-family air-gap):
+          # k3s_skip_selinux_rpm: true   # don't fetch k3s-selinux from a repo
+          # k3s_selinux_warn: true       # missing SELinux policy -> warn, not fatal
+
           deploy_helm_charts: true
           helm_repositories:
             ingress-nginx:

--- a/collections/rke/k3s.yaml
+++ b/collections/rke/k3s.yaml
@@ -12,17 +12,17 @@ playbooks:
             when: path_to_vars_file is defined
 
         vars:
-          install_k3s: trueq
+          install_k3s: true
           copy_kubeconfig: true
           fetch_kubeconfig: true
           k3s_state: present #absent
           fetched_kubeconfig_path: /tmp/kubeconfig
           prepare_rancher_ha_nodes: true #false
-          k3s_k8s_version: 1.35.1
-          cilium_version: 0.19.0
+          k3s_k8s_version: 1.36.1
+          cilium_version: 0.19.4
           k3s_release_kind: k3s1
           cluster_setup: singlenode
-          install_cillium: true
+          install_cilium: true
 
         roles:
           - role: sthings.rke.deploy_configure_rke
@@ -44,11 +44,11 @@ playbooks:
           fetch_kubeconfig: true
           fetched_kubeconfig_path: ./kubeconfig
           k3s_state: present #absent
-          k3s_k8s_version: 1.35.1
+          k3s_k8s_version: 1.36.1
           k3s_release_kind: k3s1
           cluster_setup: singlenode
           install_helm_diff: true
-          install_cillium: true
+          install_cilium: true
           deploy_helm_charts: true
           helm_repositories:
             ingress-nginx:

--- a/collections/rke/rke2.yaml
+++ b/collections/rke/rke2.yaml
@@ -14,9 +14,9 @@ playbooks:
         vars:
           rke_state: present #absent
           rke_version: 2
-          rke2_k8s_version: 1.35.1
+          rke2_k8s_version: 1.36.1
           rke2_airgapped_installation: true
-          rke2_release_kind: rke2r1 #rke2r2
+          rke2_release_kind: rke2r2 #rke2r1
           prepare_rancher_ha_nodes: true #false
           cluster_setup: singlenode
           disableKubeProxy: true
@@ -125,9 +125,9 @@ playbooks:
         vars:
           rke_state: present #absent
           rke_version: 2
-          rke2_k8s_version: 1.33.4
+          rke2_k8s_version: 1.36.1
           rke2_airgapped_installation: true
-          rke2_release_kind: rke2r1 #rke2r2
+          rke2_release_kind: rke2r2 #rke2r1
           prepare_rancher_ha_nodes: true #false
           cluster_setup: multinode
           disableKubeProxy: true


### PR DESCRIPTION
## What

Updates the `sthings.rke` collection source for the new **deploy-configure-rke `2026.06.07`** release and fixes bugs found while reviewing the k3s plays.

### `collection.yaml`
- `deploy-configure-rke`: `2026.02.16-2` → **`2026.06.07`** — pulls in everything merged this cycle: k3s air-gapped images/binary (decoupled), k3s registry pull-through mirror, SELinux toggles, Cilium teardown cleanup, and the rke2/k3s + kubectl/helm/cilium-cli version bumps. (Tag `2026.06.07` = current `main`, so it includes all of it.)
- `install-requirements`: `2025.12.12` → **`2026.04.13`** (latest). `configure-rke-node` (`2025.12.13`) and `download-install-binary` (`2025.03.27`) already at latest.

### `k3s.yaml` — bug fixes found during review
- **`install_k3s: trueq` → `true`** — real bug: `trueq` evaluates falsy, so the `k3s_cluster` play would skip the k3s install entirely.
- `k3s_k8s_version` `1.35.1` → `1.36.1`, `cilium_version` `0.19.0` → `0.19.4` — match the new role defaults.
- **`install_cillium` → `install_cilium`** (both plays) — the misspelled var was dead (did nothing; Cilium installed only because the role default is `true`). No behaviour change, now correct.

### `README.md`
- Role-version table (`deploy-configure-rke` 2026.06.07, `install-requirements` 2026.04.13) and k3s default version → `1.36.1`.

## Notes
- This updates the collection **source** only. Building/releasing the actual `sthings-rke-<ver>.tar.gz` artifact is the separate `task build-collection` (dagger) step — run that to publish the new collection.
- Scope kept to the k3s plays (as requested). The `rke2.yaml` play and rke2 README rows still show older example versions (`1.33.4`/`1.35.1`); happy to align those in a follow-up.
- New role features (k3s `k3s_airgapped_*`, `k3s_registry_mirrors`, `k3s_skip_selinux_rpm`/`k3s_selinux_warn`) are available but not yet showcased in the plays — can add commented examples if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)