### PR TITLE
feat(rke): pin deploy-configure-rke 2026.06.07-1 (registry from_yaml fix)

### DIFF
--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/deploy-configure-rke.git
       scm: git
-      version: 2026.06.07
+      version: 2026.06.07-1
     - src: https://github.com/stuttgart-things/configure-rke-node.git
       scm: git
       version: 2025.12.13


### PR DESCRIPTION
Bumps the bundled deploy-configure-rke role to 2026.06.07-1, which adds from_yaml tolerance so registry mirror/config vars work when passed as JSON strings by dagger's `-e key=value` executor (fixes `'str object' has no attribute 'name'`). Built + published as **sthings-rke-26.0.554**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)