### PR TITLE
feat(rke): pin deploy-configure-rke 2026.06.07-2 (cilium readiness gate + retry)

### DIFF
--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/deploy-configure-rke.git
       scm: git
-      version: 2026.06.07
+      version: 2026.06.07-2
     - src: https://github.com/stuttgart-things/configure-rke-node.git
       scm: git
       version: 2025.12.13


### PR DESCRIPTION
Bumps the bundled role to 2026.06.07-2 (cilium apiserver `/readyz` gate before install/upgrade + upgrade retry). Built + published as **sthings-rke-26.0.702**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)