### PR TITLE
feat(rke): pin deploy-configure-rke 2026.06.08-1 + optional Cilium air-gap

### DIFF
--- a/collections/rke/README.md
+++ b/collections/rke/README.md
@@ -72,6 +72,26 @@ ansible-galaxy collection install https://github.com/stuttgart-things/ansible/re
 | `cilium_lbrange_start_ip` | `192.168.1.10` | Cilium LB IP pool start |
 | `cilium_lbrange_stop_ip` | `192.168.1.20` | Cilium LB IP pool end |
 
+### Cilium Air-Gapped Images (optional, off by default)
+
+Cilium is installed via cilium-cli, which pulls its images from `quay.io`. On
+edge/offline nodes, pre-load those images from a tar into containerd and pin the
+pull policy so pods start without reaching out. Applies to both RKE2 and K3s; all
+options are **disabled by default** (normal online pull).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `cilium_airgapped_images` | `false` | Enable the image pre-load into containerd |
+| `cilium_airgapped_image_url` | `""` | HTTPS source for the Cilium images tar (required when enabled) |
+| `cilium_image_pull_policy` | `Always` | Pull policy on agent/operator/envoy; set `Never` on edge |
+| `cilium_airgapped_checksum` | - | Optional `sha256:...` integrity check for the tar |
+
+Build the tar from a node that already runs Cilium with
+`deploy-configure-rke`'s `hack/export-cilium-images.sh` (override
+`CTR=/var/lib/rancher/rke2/bin/ctr` for RKE2), publish it to your mirror, then set
+`cilium_airgapped_images: true`, `cilium_airgapped_image_url`, and
+`cilium_image_pull_policy: Never`.
+
 ### Vault Upload Variables
 
 | Variable | Default | Description |

--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/deploy-configure-rke.git
       scm: git
-      version: 2026.06.07-2
+      version: 2026.06.08-1
     - src: https://github.com/stuttgart-things/configure-rke-node.git
       scm: git
       version: 2025.12.13

--- a/collections/rke/k3s.yaml
+++ b/collections/rke/k3s.yaml
@@ -48,6 +48,15 @@ playbooks:
           # SELinux toggles (enforcing RHEL-family air-gap):
           # k3s_skip_selinux_rpm: true   # don't fetch k3s-selinux from a repo
           # k3s_selinux_warn: true       # missing SELinux policy -> warn, not fatal
+          # Cilium air-gapped images (off by default). cilium-cli pulls from
+          # quay.io; this pre-loads its images from a tar into containerd and
+          # pins the pull policy so pods start offline. Build the tar with
+          # deploy-configure-rke's hack/export-cilium-images.sh on a node that
+          # already runs Cilium:
+          # cilium_airgapped_images: true
+          # cilium_airgapped_image_url: "https://your-mirror/cilium-images.tar"
+          # cilium_image_pull_policy: Never                # Always (default) keeps online pull
+          # cilium_airgapped_checksum: "sha256:..."        # optional integrity check
 
         roles:
           - role: sthings.rke.deploy_configure_rke
@@ -99,6 +108,15 @@ playbooks:
           # SELinux toggles (enforcing RHEL-family air-gap):
           # k3s_skip_selinux_rpm: true   # don't fetch k3s-selinux from a repo
           # k3s_selinux_warn: true       # missing SELinux policy -> warn, not fatal
+          # Cilium air-gapped images (off by default). cilium-cli pulls from
+          # quay.io; this pre-loads its images from a tar into containerd and
+          # pins the pull policy so pods start offline. Build the tar with
+          # deploy-configure-rke's hack/export-cilium-images.sh on a node that
+          # already runs Cilium:
+          # cilium_airgapped_images: true
+          # cilium_airgapped_image_url: "https://your-mirror/cilium-images.tar"
+          # cilium_image_pull_policy: Never                # Always (default) keeps online pull
+          # cilium_airgapped_checksum: "sha256:..."        # optional integrity check
 
           deploy_helm_charts: true
           helm_repositories:

--- a/collections/rke/rke2.yaml
+++ b/collections/rke/rke2.yaml
@@ -27,6 +27,16 @@ playbooks:
             - rke2-snapshot-validation-webhook
           rke2_cni: none
           install_cilium: true
+          # === optional: Cilium air-gapped images (off by default) ==========
+          # cilium-cli pulls from quay.io; this pre-loads its images from a tar
+          # into containerd and pins the pull policy so pods start offline.
+          # Build the tar with deploy-configure-rke's hack/export-cilium-images.sh
+          # on a node that already runs Cilium (CTR=/var/lib/rancher/rke2/bin/ctr).
+          # Keep rke2_cni: none so cilium-cli (not RKE2's bundled CNI) manages it.
+          # cilium_airgapped_images: true
+          # cilium_airgapped_image_url: "https://your-mirror/cilium-images.tar"
+          # cilium_image_pull_policy: Never                # Always (default) keeps online pull
+          # cilium_airgapped_checksum: "sha256:..."        # optional integrity check
           cluster_name: "{{ cluster_name | default('rke2') }}"
           fetched_kubeconfig_path: /tmp/kubeconfig
 
@@ -138,6 +148,16 @@ playbooks:
             - rke2-snapshot-validation-webhook
           rke2_cni: none
           install_cilium: true
+          # === optional: Cilium air-gapped images (off by default) ==========
+          # cilium-cli pulls from quay.io; this pre-loads its images from a tar
+          # into containerd and pins the pull policy so pods start offline.
+          # Build the tar with deploy-configure-rke's hack/export-cilium-images.sh
+          # on a node that already runs Cilium (CTR=/var/lib/rancher/rke2/bin/ctr).
+          # Keep rke2_cni: none so cilium-cli (not RKE2's bundled CNI) manages it.
+          # cilium_airgapped_images: true
+          # cilium_airgapped_image_url: "https://your-mirror/cilium-images.tar"
+          # cilium_image_pull_policy: Never                # Always (default) keeps online pull
+          # cilium_airgapped_checksum: "sha256:..."        # optional integrity check
           cluster_name: rke2
           fetched_kubeconfig_path: "{{ cluster_name | default('kubeconfig') }}.yaml"
           rke2_registry_mirrors:


### PR DESCRIPTION
## What

Pin `deploy-configure-rke` to **2026.06.08-1** and surface its new Cilium air-gapped image feature as an **opt-in** in the rke plays.

## Changes

- **`collection.yaml`** — bump `deploy-configure-rke` 2026.06.07-2 → 2026.06.08-1 (Cilium air-gapped image pre-load into containerd + configurable pull policy + `hack/export-cilium-images.sh`).
- **`k3s.yaml` / `rke2.yaml`** — add commented `cilium_airgapped_images` / `cilium_airgapped_image_url` / `cilium_image_pull_policy` / `cilium_airgapped_checksum` blocks to the plays. **Disabled by default** — normal online pull is unchanged.
- **`README.md`** — document the optional Cilium air-gapped variables.

## Build

Built + published as [`sthings-rke-26.1.494`](https://github.com/stuttgart-things/ansible/releases/tag/sthings-rke-26.1.494). Verified the tarball bundles the pinned role (with `install-cilium.yaml` + `hack/export-cilium-images.sh`) and the air-gap options render into the k3s/rke2 playbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)