### PR TITLE
chore(rke): pin deploy-configure-rke 2026.06.08-2

### DIFF
--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/deploy-configure-rke.git
       scm: git
-      version: 2026.06.08-1
+      version: 2026.06.08-2
     - src: https://github.com/stuttgart-things/configure-rke-node.git
       scm: git
       version: 2025.12.13


### PR DESCRIPTION
Bumps the `deploy-configure-rke` role pin 2026.06.08-1 → **2026.06.08-2**, picking up the Cilium air-gapped image-import `changed_when` fix (matches `saved`/`unpack`, gated on rc==0) — verified end-to-end on a clean k3s node (harbor mirror + Cilium image tar, pods Running with pullPolicy: Never).

CI auto-builds + releases the collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)