### PR TITLE
fix(baseos): install jq to /usr/bin and use --version

### DIFF
--- a/collections/baseos/binaries.yaml
+++ b/collections/baseos/binaries.yaml
@@ -219,8 +219,8 @@ vars:
           source_url: "https://github.com/jqlang/jq/releases/download/jq-{{ jq_version }}/jq-linux-amd64"
           bin_to_copy: jq-linux-amd64
           to_remove: ""
-          bin_dir: "/usr/bin/jq"
-          version_cmd: " version"
+          bin_dir: "/usr/bin"
+          version_cmd: " --version"
           target_version: "v{{ jq_version }}"
         yq:
           bin_name: yq


### PR DESCRIPTION
## Problem
The dev play (`sthings.baseos.dev` → `binaries.yaml`) fails installing **jq** on the new ubuntu26 template (144):

```
TASK [sthings.baseos.download_install_binary : Delete -- jq]
[ERROR]: Module failed: [Errno 20] Not a directory: b'/usr/bin/jq/jq'
```

## Root cause
- `bin_dir: "/usr/bin/jq"` → role computes `install_dir = /usr/bin/jq/jq`. On images shipping jq preinstalled at `/usr/bin/jq` (a file), the delete/install step treats it as a directory → `Errno 20 Not a directory`.
- `version_cmd: " version"` → `jq version` errors on jq 1.7.x (needs `--version`), breaking the version check.

## Fix
Align jq with the existing `crossplane` entry: `bin_dir: "/usr/bin"` and `version_cmd: " --version"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)