### PR TITLE
fix(baseos): install sops/yq/vhs to /usr/bin and use --version

### DIFF
--- a/collections/baseos/binaries.yaml
+++ b/collections/baseos/binaries.yaml
@@ -61,8 +61,8 @@ playbooks:
               source_url: "https://github.com/charmbracelet/vhs/releases/download/v{{ vhs_version }}/vhs_{{ vhs_version }}_Linux_x86_64.tar.gz"
               bin_to_copy: "vhs_{{ vhs_version }}_Linux_x86_64"
               to_remove: ""
-              bin_dir: "/usr/bin/vhs"
-              version_cmd: "version"
+              bin_dir: "/usr/bin"
+              version_cmd: " --version"
               target_version: "{{ vhs_version }}"
 
           chrome_download_url: "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
@@ -138,8 +138,8 @@ vars:
           source_url: "https://github.com/getsops/sops/releases/download/v{{ sops_version }}/sops-v{{ sops_version }}.linux.amd64"
           bin_to_copy: "sops-v{{ sops_version }}.linux.amd64"
           to_remove: ""
-          bin_dir: "/usr/bin/sops"
-          version_cmd: "version"
+          bin_dir: "/usr/bin"
+          version_cmd: " --version"
           target_version: "{{ sops_version }}"
         crossplane:
           bin_name: crossplane
@@ -229,8 +229,8 @@ vars:
           source_url: "https://github.com/mikefarah/yq/releases/download/v{{ yq_version }}/yq_linux_amd64.tar.gz"
           bin_to_copy: yq_linux_amd64
           to_remove: ""
-          bin_dir: "/usr/bin/yq"
-          version_cmd: " version"
+          bin_dir: "/usr/bin"
+          version_cmd: " --version"
           target_version: "v{{ yq_version }}"
         machineshop:
           bin_name: machineshop


### PR DESCRIPTION
Follow-up to #953 (jq). The dev play now gets past jq but fails on **sops**:

```
[ERROR]: Module failed: [Errno 20] Not a directory: b'/usr/bin/sops/sops'
```

`sops`, `yq` and `vhs` have the same misconfiguration as jq did — `bin_dir: /usr/bin/<name>` → `install_dir=/usr/bin/<name>/<name>`, colliding with the preinstalled `/usr/bin/<name>` file on template 144. Fix all three to `bin_dir: /usr/bin` + `version_cmd: " --version"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)