### PR TITLE
feat(baseos): set system hostname from vm_hostname

### DIFF
--- a/collections/baseos/setup.yaml
+++ b/collections/baseos/setup.yaml
@@ -184,6 +184,11 @@ playbooks:
             when: reboot_all|bool
 
         tasks:
+          - name: Set system hostname from vm_hostname
+            ansible.builtin.hostname:
+              name: "{{ vm_hostname }}"
+            when: vm_hostname is defined and (vm_hostname | string | length > 0)
+
           - name: Install vault ca certificate to local system from multiple instances
             ansible.builtin.include_role:
               name: sthings.baseos.install_configure_vault


### PR DESCRIPTION
Adds a `Set system hostname` task to `sthings.baseos.setup` (`ansible.builtin.hostname`, gated on `vm_hostname` defined). Lets the Crossplane proxmox/vsphere AnsibleRun set the guest hostname to the VM name during the base-OS run — the ansible alternative to bpg cloud-init snippets (which need node SSH). No-op when `vm_hostname` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)