### PR TITLE
fix(container): install binaries to /usr/bin (not /usr/bin/<name>)

### DIFF
--- a/collections/container/apps.yaml
+++ b/collections/container/apps.yaml
@@ -34,7 +34,7 @@ playbooks:
               source_url: "https://github.com/helmfile/helmfile/releases/download/v{{ helmfile_version }}/helmfile_{{ helmfile_version }}_linux_amd64.tar.gz"
               bin_to_copy: helmfile
               to_remove: "helmfile"
-              bin_dir: "/usr/bin/helmfile"
+              bin_dir: "/usr/bin"
               version_cmd: "version"
               target_version: "{{ helmfile_version }}"
             helm:
@@ -44,7 +44,7 @@ playbooks:
               source_url: "https://get.helm.sh/helm-v{{ helm_version }}-linux-amd64.tar.gz"
               bin_to_copy: "linux-amd64/helm"
               to_remove: "helm"
-              bin_dir: "/usr/bin/helm"
+              bin_dir: "/usr/bin"
               version_cmd: "version"
               target_version: "{{ helm_version }}"
             k9s:
@@ -54,7 +54,7 @@ playbooks:
               source_url: "https://github.com/derailed/k9s/releases/download/v{{ k9s_version }}/k9s_Linux_amd64.tar.gz"
               bin_to_copy: "k9s"
               to_remove: "k9s"
-              bin_dir: "/usr/bin/k9s"
+              bin_dir: "/usr/bin"
               version_cmd: "version"
               target_version: "{{ k9s_version }}"
 

--- a/collections/container/k3s.yaml
+++ b/collections/container/k3s.yaml
@@ -88,7 +88,7 @@ vars:
           source_url: "https://github.com/cilium/cilium-cli/releases/download/v{{ cilium_version }}/cilium-linux-amd64.tar.gz"
           bin_to_copy: cilium
           to_remove: ""
-          bin_dir: "/usr/bin/cilium"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ cilium_version }}"
         helm:

--- a/collections/container/tools.yaml
+++ b/collections/container/tools.yaml
@@ -44,7 +44,7 @@ vars:
           source_url: "https://github.com/helmfile/vals/releases/download/v{{ vals_version }}/vals_{{ vals_version }}_linux_amd64.tar.gz"
           bin_to_copy: vals
           to_remove: ""
-          bin_dir: "/usr/bin/vcluster"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ vcluster_version }}"
         vcluster:
@@ -54,7 +54,7 @@ vars:
           source_url: "https://github.com/loft-sh/vcluster/releases/download/v{{ vcluster_version }}/vcluster-linux-amd64"
           bin_to_copy: vcluster-linux-amd64
           to_remove: ""
-          bin_dir: "/usr/bin/vcluster"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ vcluster_version }}"
         tkn:
@@ -74,7 +74,7 @@ vars:
           source_url: "https://github.com/fluxcd/flux2/releases/download/v{{ flux_version }}/flux_{{ flux_version }}_linux_amd64.tar.gz"
           bin_to_copy: flux
           to_remove: ""
-          bin_dir: "/usr/bin/flux"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ flux_version }}"
         argocd:
@@ -84,7 +84,7 @@ vars:
           source_url: "https://github.com/argoproj/argo-cd/releases/download/v{{ argocd_version }}/argocd-linux-amd64"
           bin_to_copy: argocd-linux-amd64
           to_remove: ""
-          bin_dir: "/usr/bin/argocd"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ argocd_version }}"
         kind:
@@ -94,7 +94,7 @@ vars:
           source_url: "https://github.com/kubernetes-sigs/kind/releases/download/v{{ kind_version }}/kind-linux-amd64"
           bin_to_copy: kind-linux-amd64
           to_remove: ""
-          bin_dir: "/usr/bin/kind"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ kind_version }}"
         skopeo:
@@ -104,7 +104,7 @@ vars:
           source_url: "https://github.com/lework/skopeo-binary/releases/download/v{{ skopeo_version }}/skopeo-linux-amd64"
           bin_to_copy: skopeo-linux-amd64
           to_remove: ""
-          bin_dir: "/usr/bin/skopeo"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "v{{ skopeo_version }}"
         helm:
@@ -184,7 +184,7 @@ vars:
           source_url: "https://github.com/cilium/cilium-cli/releases/download/v{{ cilium_version }}/cilium-linux-amd64.tar.gz"
           bin_to_copy: cilium
           to_remove: ""
-          bin_dir: "/usr/bin/cilium"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ cilium_version }}"
         xpdig:
@@ -194,7 +194,7 @@ vars:
           source_url: "https://github.com/brunoluiz/xpdig/releases/download/v{{ xpdig_version }}/xpdig_Linux_x86_64.tar.gz"
           bin_to_copy: xpdig
           to_remove: ""
-          bin_dir: "/usr/bin/xpdig"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ xpdig_version }}"
         dagger:
@@ -204,6 +204,6 @@ vars:
           source_url: "https://github.com/dagger/dagger/releases/download/v{{ dagger_version }}/dagger_v{{ dagger_version }}_linux_amd64.tar.gz"
           bin_to_copy: dagger
           to_remove: ""
-          bin_dir: "/usr/bin/dagger"
+          bin_dir: "/usr/bin"
           version_cmd: "version"
           target_version: "{{ dagger_version }}"


### PR DESCRIPTION
Same class of bug as baseos #953/#954 (jq/sops/yq/vhs). The container collection sets `bin_dir: /usr/bin/<name>` for **helmfile, helm, k9s, vcluster, flux, argocd, kind, skopeo, cilium, xpdig, dagger**, so `download_install_binary` computes `install_dir=/usr/bin/<name>/<name>` and fails with `[Errno 20] Not a directory` on images that preinstall the tool at `/usr/bin/<name>` (template 144). The dev play hit this on `vcluster`. Point all of them at `bin_dir: /usr/bin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)