### PR TITLE
fix(baseos): install ko to /usr/bin (not /usr/bin/ko)

### DIFF
--- a/collections/baseos/golang.yaml
+++ b/collections/baseos/golang.yaml
@@ -40,7 +40,7 @@ playbooks:
               source_url: "https://github.com/ko-build/ko/releases/download/v{{ ko_version }}/ko_Linux_x86_64.tar.gz"
               bin_to_copy: ko
               to_remove: ""
-              bin_dir: "/usr/bin/ko"
+              bin_dir: "/usr/bin"
               version_cmd: "version"
               target_version: "{{ ko_version }}"
 


### PR DESCRIPTION
Last instance of the `bin_dir: /usr/bin/<name>` anti-pattern (after #953 jq, #954 sops/yq/vhs, #957 container). `ko` in golang.yaml → `bin_dir: /usr/bin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)