### PR TITLE
fix(baseos): drop leading v from dev-play kind_version (vv0.31.0 -> 404)

### DIFF
--- a/collections/baseos/developer.yaml
+++ b/collections/baseos/developer.yaml
@@ -123,7 +123,7 @@ playbooks:
       - name: Create kind dev cluster
         ansible.builtin.import_playbook: sthings.container.kind
         vars:
-          kind_version: v0.31.0
+          kind_version: 0.31.0
           api_server_address: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
           kind_cluster_name: dev
           ansible_user: sthings


### PR DESCRIPTION
The `sthings.baseos.dev` play's *Create kind dev cluster* step set `kind_version: v0.31.0`, but `sthings.container.kind` downloads from `.../download/v{{ kind_version }}/...` → `.../download/**vv**0.31.0/kind-linux-amd64` → HTTP 404. Drop the leading `v` (kind tags are `v0.31.0`; the URL template already adds it). Last blocker for the dev play (was at ok≈790/995).

🤖 Generated with [Claude Code](https://claude.com/claude-code)