### PR TITLE
fix: bump install-configure-docker role to 2026.06.24 (bin_dir /usr/bin)

### DIFF
--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/install-configure-docker.git
       scm: git
-      version: 2026.05.09
+      version: 2026.06.24
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
       version: 2026.04.13


### PR DESCRIPTION
Bumps the `install-configure-docker` role pin in the container collection to `2026.06.24`, pulling in [install-configure-docker#35](https://github.com/stuttgart-things/install-configure-docker/pull/35): `kind/helmfile/helm/k9s/yq` `bin_dir` now `/usr/bin` instead of `/usr/bin/<name>`.

Fixes the last `[Errno 20] Not a directory` failures in the `sthings.baseos.dev` play against base-os template 144. Opening this PR triggers a new container collection build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)