### PR TITLE
fix: bump install-configure-docker role pin to 2026.06.25 (kind/yq bin_dir)

### DIFF
--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/install-configure-docker.git
       scm: git
-      version: 2026.06.24
+      version: 2026.06.25
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
       version: 2026.04.13


### PR DESCRIPTION
Carries install-configure-docker#36 — the kind/yq `bin_dir` rename-trick fix. Fixes the dev play failing at the kind-config validation step with `yq: not found` (yq/kind were landing under the wrong filename after the blanket `/usr/bin` fix in role #35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)