### PR TITLE
chore(container): bump install-configure-docker role 2026.06.25 → 2026.07.11

### DIFF
--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/install-configure-docker.git
       scm: git
-      version: 2026.06.25
+      version: 2026.07.11
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
       version: 2026.04.13


### PR DESCRIPTION
Bumps the `install-configure-docker` role pin in the **container** collection `2026.06.25 → 2026.07.11`, picking up [install-configure-docker#38](https://github.com/stuttgart-things/install-configure-docker/pull/38) (merged, tagged `2026.07.11`):

- **kind default `0.32.0`** — `0.31.0` digest-mismatches `kindest/node:v1.35.0`, breaking any consumer that doesn't override `kind_version` (e.g. `kind_xplane_cluster`).
- **kubeconfig `0.0.0.0 → 127.0.0.1`** — kind writes `server: https://0.0.0.0:<port>` in the default path; the apiserver cert only covers `127.0.0.1`, so the role's own `Verify kind cluster` (and local `kubectl`) fail TLS. Now normalized idempotently.

The third fix from the e2e (docker-group race → `meta: reset_connection`) was already in `2026.06.25`; this only adds the two above.

### Why only the container collection
`baseos` (pins `2026.05.09`) and `awx` (pins `2025.04.24`) reference the same role but are independently versioned and intentionally lag — they aren't the k8s-1.35 kind bootstrap path, so they're left untouched here.

### Context
Fixes the `kind` / `kind_xplane_cluster` / `kind_machinery_profile` flow on k8s 1.35 out of the box. Full write-up + verification in [#988](https://github.com/stuttgart-things/ansible/issues/988#issuecomment-4945797390) (validated e2e `failed=0` on a fresh labul VM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
