### PR TITLE
ci: fix dispatch runner (→ ubuntu-latest) + build on PR synchronize

### DIFF
--- a/.github/workflows/dispatch-collection-build.yml
+++ b/.github/workflows/dispatch-collection-build.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   collection-build:
     name: Collection Build
-    runs-on: dagger-labul
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
       - reopened
+      - synchronize
+      - ready_for_review
     paths:
       - 'collections/**'
 


### PR DESCRIPTION
Two CI fixes surfaced while validating #989:

- **`dispatch-collection-build.yml`**: `dagger-labul` self-hosted runner is offline — a manual dispatch sat queued indefinitely. Switch to `ubuntu-latest` (the runner the PR build path already uses).
- **`pr-collection-build.yaml`**: add `synchronize` + `ready_for_review` to the `pull_request` trigger so pushes to an open collection PR (and draft→ready) re-run the build — today it only fires on `opened`/`reopened`, so updates need a manual close/reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)