### PR TITLE
chore(container): bump download-install-binary role to 2026.07.13

### DIFF
--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -17,4 +17,4 @@ requirements: |
       version: 2022.01.01
     - src: https://github.com/stuttgart-things/download-install-binary.git
       scm: git
-      version: 2025.03.27
+      version: 2026.07.13


### PR DESCRIPTION
Bumps the `download-install-binary` role pin in the `container` collection from `2025.03.27` → `2026.07.13`.

The new role release carries the `install_path` fix: binaries whose `bin_dir` is a full file path (e.g. yq at `/usr/bin/yq`) no longer crash `delete` with `[Errno 20] Not a directory`, and the installed-path detection no longer forces needless reinstalls.

Opening this PR triggers the collection build → new `sthings-container-*.tar.gz` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)