### PR TITLE
chore(container): bump install-configure-docker role to 2026.07.14

### DIFF
--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/install-configure-docker.git
       scm: git
-      version: 2026.07.11
+      version: 2026.07.14
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
       version: 2026.04.13


### PR DESCRIPTION
Bumps the `install-configure-docker` role pin in the `container` collection from `2026.07.11` → `2026.07.14`.

Picks up the yq `version_cmd` fix (`yq --version`) so yq is no longer needlessly re-downloaded/re-copied on every run (download-install-binary#50 item 2b).

Opening this PR triggers the collection build → new `sthings-container-*.tar.gz` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)