### PR TITLE
chore(container): bump download-install-binary role to 2026.07.15

### DIFF
--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -17,4 +17,4 @@ requirements: |
       version: 2022.01.01
     - src: https://github.com/stuttgart-things/download-install-binary.git
       scm: git
-      version: 2026.07.13
+      version: 2026.07.15


### PR DESCRIPTION
Bumps the `download-install-binary` role pin in the `container` collection `2026.07.13` → `2026.07.15`.

Picks up download-install-binary#50 items **2a** (exact version match via anchored regex, no more `1.2`-matches-`1.2.3`), **3** + **4** (delete gated on `wanted_state==absent` only; reinstall relies on `force: true` copy).

Triggers the collection build → new `sthings-container-*.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)