### PR TITLE
fix(baseos): probe vault instances before installing the CA

### DIFF
--- a/collections/baseos/setup.yaml
+++ b/collections/baseos/setup.yaml
@@ -189,16 +189,47 @@ playbooks:
               name: "{{ vm_hostname }}"
             when: vm_hostname is defined and (vm_hostname | string | length > 0)
 
-          - name: Install vault ca certificate to local system from multiple instances
+          # vault_instances is an infra-wide list, but any single entry can be
+          # sealed, down or behind a broken ingress at any time. Installing the
+          # CA straight from the list made ONE such instance fail the whole
+          # play — and therefore every VM build in the fleet. So probe first and
+          # only install from the instances that actually serve the CA.
+          - name: Probe vault instances for a reachable PKI CA endpoint
+            ansible.builtin.uri:
+              url: "{{ vault_instance }}/v1/pki/ca/pem"
+              method: GET
+              validate_certs: false
+              timeout: 10
+            loop: "{{ vault_instances }}"
+            loop_control:
+              loop_var: vault_instance
+            register: vault_ca_probe
+            failed_when: false
+            changed_when: false
+            when: vault_instances is defined
+
+          - name: Report unreachable vault instances
+            ansible.builtin.debug:
+              msg: >-
+                Skipping vault CA install from {{ item.vault_instance }} —
+                not reachable ({{ item.msg | default('status ' ~ (item.status | default('unknown'))) }})
+            loop: "{{ vault_ca_probe.results | default([]) | rejectattr('status', 'defined') | list
+                      + vault_ca_probe.results | default([]) | selectattr('status', 'defined') | rejectattr('status', 'equalto', 200) | list }}"
+            loop_control:
+              label: "{{ item.vault_instance }}"
+
+          - name: Install vault ca certificate to local system from reachable instances
             ansible.builtin.include_role:
               name: sthings.baseos.install_configure_vault
               tasks_from: install-ca-auth
             vars:
               vault_url: "{{ vault_instance }}"
-            loop: "{{ vault_instances }}"
+            loop: "{{ vault_ca_probe.results | default([])
+                      | selectattr('status', 'defined')
+                      | selectattr('status', 'equalto', 200)
+                      | map(attribute='vault_instance') | list }}"
             loop_control:
               loop_var: vault_instance
-            when: vault_instances is defined
 
           - name: Send event to homerun if enabled
             block:


### PR DESCRIPTION
## Problem

`sthings.baseos.setup` installs the Vault CA by looping a hardcoded four-entry `vault_instances` list, gated only on `when: vault_instances is defined` and with no error handling. One sealed or unreachable instance fails the **whole play** — and therefore every AnsibleRun-driven VM build in the fleet:

```
fatal: [10.31.103.22]: FAILED! => {"json": {"errors": ["Vault is sealed"]},
  "msg": "Status code was 503 and not [200]: HTTP Error 503: Service Unavailable",
  "url": "https://vault-vsphere.labul.sva.de:8200/v1/pki/ca/pem"}
```

Hit twice in one afternoon while building a test VM: first `vault-vsphere.labul` was sealed, then after unsealing it `vault.infra.sthings-vsphere.labul` was down behind its ingress (envoy 503). Each time, 90+ successful tasks were thrown away.

The list is infra-wide but the failure is per-instance — a LabUL VM build has no reason to break because a LabDA Vault is sealed.

## Fix

Probe each instance's PKI CA endpoint first (`failed_when: false`), then include the role only for those that answered 200.

Skipped instances are logged rather than silently swallowed, so a persistently dead instance stays visible instead of quietly rotting.

## Note on the workaround

Until this ships, the only way to get past it is to override the list from the XR's `varsFile`. That works because the Tekton task writes EXTRA_VARS verbatim as `key: value`, so a YAML flow sequence survives what otherwise looks like a scalar-only interface:

```yaml
- 'vault_instances+-["https://vault-vsphere.labul.sva.de:8200"]'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo