### PR TITLE
chore(container): bump install-configure-docker to 2026.07.19

### DIFF
--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -5,7 +5,7 @@ requirements: |
   roles:
     - src: https://github.com/stuttgart-things/install-configure-docker.git
       scm: git
-      version: 2026.07.14
+      version: 2026.07.19
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
       version: 2026.04.13


### PR DESCRIPTION
Picks up the kind kubeconfig fix ([install-configure-docker#40](https://github.com/stuttgart-things/install-configure-docker/pull/40)).

`api_server_port` was regenerated at random on every run and written into the kubeconfig even when the cluster was not recreated, so every second run of the kind play produced a kubeconfig pointing at a port nothing was listening on (`connection refused`) and failed its own verify step. The port is now read back from kind itself.

Needed on the way to a reproducible kind test cluster built via `NativeVsphereVM` + `AnsibleRun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo