### PR TITLE
fix(container): store kubeconfig in Vault raw, not base64

### DIFF
--- a/collections/container/kind.yaml
+++ b/collections/container/kind.yaml
@@ -204,6 +204,11 @@ playbooks:
             delegate_to: localhost
             when: replace_ip|bool
 
+          # Stored RAW, not base64. Vault KVv2 values are JSON strings and hold
+          # YAML fine, so the encoding was redundant — and provider-kubeconfig
+          # (RemoteCluster with source.type: vault) hands the value straight to
+          # clientcmd.RESTConfigFromKubeConfig with no decode step, so a base64
+          # blob fails to parse.
           - name: Write kubeconfig to vault using key value V2 engine
             community.hashi_vault.vault_write:
               auth_method: approle
@@ -214,7 +219,7 @@ playbooks:
               path: "{{ secret_path_kubeconfig }}/data/{{ cluster_name }}"
               data:
                 data:
-                  kubeconfig: "{{ lookup('ansible.builtin.file', kubeconfig_path|basename)|b64encode }}"
+                  kubeconfig: "{{ lookup('ansible.builtin.file', kubeconfig_path|basename) }}"
             delegate_to: localhost
 
   - name: get_controlplane_ip


### PR DESCRIPTION
## Problem

`upload_kubeconfig_vault` base64-encodes the kubeconfig before writing it to the KVv2 `kubeconfigs` mount:

```yaml
kubeconfig: "{{ lookup('ansible.builtin.file', kubeconfig_path|basename)|b64encode }}"
```

Vault KVv2 values are JSON strings and hold YAML fine, so the encoding is redundant. Worse, it makes the entry **unusable by provider-kubeconfig**, whose `RemoteCluster` vault source hands the value straight to `clientcmd.RESTConfigFromKubeConfig`:

```go
val, ok := data[key]
content, ok := val.(string)
return []byte(content), version, nil
```

There is no `base64` decode anywhere in that provider (`grep -rn base64 --include='*.go'` → nothing), so a base64 blob fails to parse. That blocks registering an ansible-built cluster as a `RemoteCluster` — which is the whole point of putting the kubeconfig in Vault, since `RemoteCluster` is what emits the downstream `ClusterProviderConfig`s that `flux-init` / `platform` target by `clusterName`.

## Migration debt (deliberately not in this PR)

Worth knowing before merging: the `kubeconfigs/` mount currently holds **14 entries, all base64**, e.g.

```
xplane-dev  -> 'YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1' ("apiVersion: v1\nclusters:\n- clu")
```

and the sibling writers do the same thing:

- `collections/rke/rke2.yaml`
- `plays/upload-kubeconfig-k3s.yaml`

So after this merge the mount holds mixed encodings. **Nothing breaks today** — there is no vault-source `RemoteCluster` anywhere in the fleet, so nothing currently reads these through the provider. But it is a trap for whoever wires up the next cluster.

Two follow-ups worth deciding on:

1. Convert `rke2.yaml` + `upload-kubeconfig-k3s.yaml` the same way, and rewrite the existing entries — makes the mount uniformly raw.
2. Or make provider-kubeconfig detect-and-decode base64, which would keep the existing entries working as-is.

I went with raw here because it is the simpler convention and matches what the provider already expects from the git/sops path (which yields raw YAML after decryption). Happy to do (1) as a follow-up if you agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo
