### PR TITLE
fix(container): bump sops-secrets-operator to v0.8.5 and pin its image

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -86,8 +86,14 @@ playbooks:
 
           # --- component refs / versions ---
           helm_repo: "git::https://github.com/stuttgart-things/helm.git"
-          sops_operator_ref: v0.8.4
+          sops_operator_ref: v0.8.5
           sops_operator_kustomize: "https://github.com/stuttgart-things/sops-secrets-operator/config/default"
+          # Must be set explicitly: the operator's in-repo kustomize base pins the
+          # PREVIOUS release's image, so `apply -k ...?ref=v0.8.5` deploys v0.8.4.
+          # Verified across four tags (v0.8.5->v0.8.4, v0.8.4->v0.8.3, ...) —
+          # stuttgart-things/sops-secrets-operator#86. Drop the pin task below
+          # once that is fixed and the ref alone selects the right image.
+          sops_operator_image: "ghcr.io/stuttgart-things/sops-secrets-operator:v0.8.5"
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.3.6"
           cert_manager_version: v1.21.0
@@ -210,6 +216,14 @@ playbooks:
           - name: Deploy sops-secrets-operator (kustomize)
             ansible.builtin.command: >
               kubectl apply -k {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
+              --kubeconfig {{ kubeconfig }}
+            become_user: "{{ ansible_user }}"
+
+          - name: Pin the sops-secrets-operator image (kustomize base lags a release)
+            ansible.builtin.command: >
+              kubectl -n sops-secrets-operator-system set image
+              deploy/sops-secrets-operator-controller-manager
+              manager={{ sops_operator_image }}
               --kubeconfig {{ kubeconfig }}
             become_user: "{{ ansible_user }}"
 
@@ -426,8 +440,14 @@ playbooks:
           vault_approle_role_id: ""
 
           helm_repo: "git::https://github.com/stuttgart-things/helm.git"
-          sops_operator_ref: v0.8.4
+          sops_operator_ref: v0.8.5
           sops_operator_kustomize: "https://github.com/stuttgart-things/sops-secrets-operator/config/default"
+          # Must be set explicitly: the operator's in-repo kustomize base pins the
+          # PREVIOUS release's image, so `apply -k ...?ref=v0.8.5` deploys v0.8.4.
+          # Verified across four tags (v0.8.5->v0.8.4, v0.8.4->v0.8.3, ...) —
+          # stuttgart-things/sops-secrets-operator#86. Drop the pin task below
+          # once that is fixed and the ref alone selects the right image.
+          sops_operator_image: "ghcr.io/stuttgart-things/sops-secrets-operator:v0.8.5"
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.3.6"
           cert_manager_version: v1.21.0
@@ -521,6 +541,13 @@ playbooks:
           - name: Deploy sops-secrets-operator (kustomize)
             ansible.builtin.command: >
               kubectl apply -k {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
+              --kubeconfig {{ kubeconfig }}
+
+          - name: Pin the sops-secrets-operator image (kustomize base lags a release)
+            ansible.builtin.command: >
+              kubectl -n sops-secrets-operator-system set image
+              deploy/sops-secrets-operator-controller-manager
+              manager={{ sops_operator_image }}
               --kubeconfig {{ kubeconfig }}
 
           - name: Wait for sops-secrets-operator controller rollout


### PR DESCRIPTION
v0.8.5 carries the fix for the operator never re-applying a target Secret that was removed out of band ([sops-secrets-operator#83](https://github.com/stuttgart-things/sops-secrets-operator/issues/83)) — a successful reconcile was terminal, so a deleted Secret stayed deleted while the CR kept reporting `Applied=True`.

Verified on the reference cluster right after bumping it:

```
Secret deleted   14:51:58
RESTORED after ~30s, no manual intervention
hash before/after identical
```

Before the bump the same Secret did not come back at all — not after nine minutes, well past the source interval.

## Why the ref bump alone is not enough

The operator's in-repo kustomize base pins the **previous** release's image, so `apply -k …?ref=v0.8.5` deploys **v0.8.4**:

```
v0.8.5 -> v0.8.4     v0.8.3 -> v0.8.2
v0.8.4 -> v0.8.3     v0.8.2 -> v0.8.1
```

Four for four — tracked as [sops-secrets-operator#86](https://github.com/stuttgart-things/sops-secrets-operator/issues/86). I hit this bumping the reference cluster: the apply reported success and left the old image running.

So both plays gain a `set image` task **between the apply and the rollout wait**. That ordering is deliberate — the wait then covers the new image rather than the one the bundle brought.

```yaml
sops_operator_ref: v0.8.5
sops_operator_image: "ghcr.io/stuttgart-things/sops-secrets-operator:v0.8.5"
```

`sops_operator_image` and the pin task should both be dropped once #86 lands and the ref alone selects the right image; the comment in the vars block says so.

## Verification

- both plays pass `--syntax-check`
- the rendered command is identical to the one applied by hand to the reference cluster
- `pre-commit run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo