### PR TITLE
fix(baseos): bump create-os-user to 2026.07.22

### DIFF
--- a/collections/baseos/collection.yaml
+++ b/collections/baseos/collection.yaml
@@ -10,7 +10,7 @@ requirements: |
       version: 2025.01.14
     - src: https://github.com/stuttgart-things/create-os-user.git
       scm: git
-      version: 2025.10.11
+      version: 2026.07.22
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
       version: 2026.04.13


### PR DESCRIPTION
Picks up [stuttgart-things/create-os-user#6](https://github.com/stuttgart-things/create-os-user/pull/6), released as `2026.07.22`.

`tasks/create-admin-group.yaml` (4×) and the `admin_group` default (1×) now read `ansible_facts['os_family']` / `['distribution']` instead of the injected top-level vars.

Those were the last `INJECT_FACTS_AS_VARS` deprecation warnings in the stuttgart-things packer base-OS builds. They are not only noise: once the default flips, the bare names resolve to *undefined*, every `when` in `create-admin-group.yaml` evaluates false, and no sudoers entry is written — with the run still reporting `failed=0`. The `admin_group` default would quietly resolve to `admin` on every OS, a group that exists on neither Debian nor RedHat.

Jinja semantics verified unchanged across all four branches:

| facts | before | after |
|---|---|---|
| Debian / Ubuntu | `sudo` | `sudo` |
| RedHat / Rocky | `wheel` | `wheel` |
| Suse / SLES | `wheel` | `wheel` |
| anything else | `admin` | `admin` |

Merging this produces a new `sthings-baseos` release, which then needs pinning in `stuttgart-things/stuttgart-things` → `packer/builds/ubuntu24-labul-vsphere-base-os/requirements.yaml` (currently `26.0.387`, set in #2390 earlier today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF