### PR TITLE
chore(container): bump sops-secrets-operator to v0.9.0 and drop the image pin

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -86,14 +86,13 @@ playbooks:
 
           # --- component refs / versions ---
           helm_repo: "git::https://github.com/stuttgart-things/helm.git"
-          sops_operator_ref: v0.8.5
+          # From v0.9.0 the ref alone selects the image: semantic-release now
+          # writes config/manager/kustomization.yaml before it tags, so the
+          # tagged tree pins its own release. Verified by building the bundle:
+          # ref=v0.8.5 -> image v0.8.4 (the old off-by-one),
+          # ref=v0.9.0 -> image v0.9.0. sops-secrets-operator#86, fixed by #90.
+          sops_operator_ref: v0.9.0
           sops_operator_kustomize: "https://github.com/stuttgart-things/sops-secrets-operator/config/default"
-          # Must be set explicitly: the operator's in-repo kustomize base pins the
-          # PREVIOUS release's image, so `apply -k ...?ref=v0.8.5` deploys v0.8.4.
-          # Verified across four tags (v0.8.5->v0.8.4, v0.8.4->v0.8.3, ...) —
-          # stuttgart-things/sops-secrets-operator#86. Drop the pin task below
-          # once that is fixed and the ref alone selects the right image.
-          sops_operator_image: "ghcr.io/stuttgart-things/sops-secrets-operator:v0.8.5"
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.3.6"
           cert_manager_version: v1.21.0
@@ -216,14 +215,6 @@ playbooks:
           - name: Deploy sops-secrets-operator (kustomize)
             ansible.builtin.command: >
               kubectl apply -k {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
-              --kubeconfig {{ kubeconfig }}
-            become_user: "{{ ansible_user }}"
-
-          - name: Pin the sops-secrets-operator image (kustomize base lags a release)
-            ansible.builtin.command: >
-              kubectl -n sops-secrets-operator-system set image
-              deploy/sops-secrets-operator-controller-manager
-              manager={{ sops_operator_image }}
               --kubeconfig {{ kubeconfig }}
             become_user: "{{ ansible_user }}"
 
@@ -440,14 +431,13 @@ playbooks:
           vault_approle_role_id: ""
 
           helm_repo: "git::https://github.com/stuttgart-things/helm.git"
-          sops_operator_ref: v0.8.5
+          # From v0.9.0 the ref alone selects the image: semantic-release now
+          # writes config/manager/kustomization.yaml before it tags, so the
+          # tagged tree pins its own release. Verified by building the bundle:
+          # ref=v0.8.5 -> image v0.8.4 (the old off-by-one),
+          # ref=v0.9.0 -> image v0.9.0. sops-secrets-operator#86, fixed by #90.
+          sops_operator_ref: v0.9.0
           sops_operator_kustomize: "https://github.com/stuttgart-things/sops-secrets-operator/config/default"
-          # Must be set explicitly: the operator's in-repo kustomize base pins the
-          # PREVIOUS release's image, so `apply -k ...?ref=v0.8.5` deploys v0.8.4.
-          # Verified across four tags (v0.8.5->v0.8.4, v0.8.4->v0.8.3, ...) —
-          # stuttgart-things/sops-secrets-operator#86. Drop the pin task below
-          # once that is fixed and the ref alone selects the right image.
-          sops_operator_image: "ghcr.io/stuttgart-things/sops-secrets-operator:v0.8.5"
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.3.6"
           cert_manager_version: v1.21.0
@@ -541,13 +531,6 @@ playbooks:
           - name: Deploy sops-secrets-operator (kustomize)
             ansible.builtin.command: >
               kubectl apply -k {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
-              --kubeconfig {{ kubeconfig }}
-
-          - name: Pin the sops-secrets-operator image (kustomize base lags a release)
-            ansible.builtin.command: >
-              kubectl -n sops-secrets-operator-system set image
-              deploy/sops-secrets-operator-controller-manager
-              manager={{ sops_operator_image }}
               --kubeconfig {{ kubeconfig }}
 
           - name: Wait for sops-secrets-operator controller rollout


### PR DESCRIPTION
Removes the workaround added in #1014.

## Why it can go

`kubectl apply -k <config/default>?ref=<tag>` used to deploy the release **before** the one the ref names, because the operator's in-repo kustomize base was never updated at release time. stuttgart-things/sops-secrets-operator#90 fixed that at the source — semantic-release now writes `config/manager/kustomization.yaml` during `prepare`, which runs before the tag is created, so a tagged tree pins its own release. **v0.9.0 is the first release carrying it.**

Verified by building the bundle, not by reading the file:

```console
$ kubectl kustomize ".../config/default?ref=v0.8.5" | grep image:
        image: ghcr.io/stuttgart-things/sops-secrets-operator:v0.8.4   # the old off-by-one

$ kubectl kustomize ".../config/default?ref=v0.9.0" | grep image:
        image: ghcr.io/stuttgart-things/sops-secrets-operator:v0.9.0   # correct
```

So `sops_operator_image` and the `kubectl set image` task come out of **both** plays; `sops_operator_ref: v0.9.0` alone now selects the image.

## Checks

- both embedded plays parse and pass `ansible-playbook --syntax-check`
- task counts 23 → 22 in each play, symmetric, `apply -k` → `rollout status` sequence intact
- no `sops_operator_image` / `set image` references left

## What this deliberately does not do

v0.9.0 also ships the shared-credential work (sops-secrets-operator#47, #48): a global age key and git/object credential via operator flags, plus optional cross-namespace `secretRef`/`keyRef`.

This playbook still installs the age key into **every** consumer namespace. A single `--global-age-key-secret` would let that loop disappear, which is exactly the friction #47 was filed about — but it is a behaviour change, so it belongs in its own PR rather than riding along with a version bump.

## Untested here

I have not run the playbook against a cluster for this change. What is verified is the mechanism it depends on (the bundle above) and that the plays are structurally intact. The next real `kind_machinery` run is the end-to-end proof.