### PR TITLE
feat(container): give the sops operator a global age key

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -74,6 +74,8 @@ playbooks:
           age_key_namespaces:
             - crossplane-system
             - tekton-ci
+            # where --global-age-key-secret points
+            - sops-secrets-operator-system
 
           # --- provider-kubeconfig / Vault-backed RemoteCluster (optional) ---
           # Emits the `vault-kubeconfigs` ClusterProviderConfig that RemoteCluster
@@ -93,6 +95,15 @@ playbooks:
           # ref=v0.9.0 -> image v0.9.0. sops-secrets-operator#86, fixed by #90.
           sops_operator_ref: v0.9.0
           sops_operator_kustomize: "https://github.com/stuttgart-things/sops-secrets-operator/config/default"
+          sops_operator_namespace: sops-secrets-operator-system
+          sops_operator_overlay_dir: "/home/{{ ansible_user }}/.cache/sops-operator-overlay"
+          sops_age_key_data_key: age.agekey
+          # v0.9.0 (sops-secrets-operator#47) lets the operator hold one age key
+          # for resources that omit spec.decryption.keyRef. Enabling it here does
+          # NOT remove the per-namespace copies below: the capability charts
+          # still render an explicit keyRef, and a resource's own reference wins
+          # over the global default. Groundwork — see the PR.
+          sops_global_age_key_enabled: true
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.3.6"
           cert_manager_version: v1.21.0
@@ -247,9 +258,44 @@ playbooks:
               done
             become_user: "{{ ansible_user }}"
 
+          # Deployed through a thin local overlay rather than `apply -k <remote>`
+          # directly, so the manager's flags are part of the applied desired
+          # state. A `kubectl patch` after the apply would be undone by the next
+          # run — the same post-hoc mutation this playbook just dropped for the
+          # image pin (#1018).
+          - name: Create the sops-secrets-operator overlay dir
+            ansible.builtin.file:
+              path: "{{ sops_operator_overlay_dir }}"
+              state: directory
+              mode: "0755"
+            become_user: "{{ ansible_user }}"
+
+          - name: Render the sops-secrets-operator kustomize overlay
+            ansible.builtin.copy:
+              dest: "{{ sops_operator_overlay_dir }}/kustomization.yaml"
+              mode: "0644"
+              content: |
+                ---
+                resources:
+                  - {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
+                {% if sops_global_age_key_enabled | bool %}
+                patches:
+                  - target:
+                      kind: Deployment
+                      name: sops-secrets-operator-controller-manager
+                    patch: |-
+                      - op: add
+                        path: /spec/template/spec/containers/0/args/-
+                        value: --global-age-key-secret={{ sops_operator_namespace }}/sops-age-key
+                      - op: add
+                        path: /spec/template/spec/containers/0/args/-
+                        value: --global-age-key-data-key={{ sops_age_key_data_key }}
+                {% endif %}
+            become_user: "{{ ansible_user }}"
+
           - name: Deploy sops-secrets-operator (kustomize)
             ansible.builtin.command: >
-              kubectl apply -k {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
+              kubectl apply -k {{ sops_operator_overlay_dir }}
               --kubeconfig {{ kubeconfig }}
             become_user: "{{ ansible_user }}"
 
@@ -482,7 +528,7 @@ playbooks:
           platform_enabled: true                     # false = pure VM builder, no cni/Flux/platform
           sops_age_key: "{{ lookup('env', 'SOPS_AGE_KEY') }}"
           secrets_dir: "/home/{{ ansible_user }}/projects/stuttgart-things/secrets"
-          age_key_namespaces: [crossplane-system, tekton-ci]
+          age_key_namespaces: [crossplane-system, tekton-ci, sops-secrets-operator-system]
 
           # See the profile play above for the full commentary on these.
           vault_kubeconfigs_enabled: false
@@ -496,6 +542,15 @@ playbooks:
           # ref=v0.9.0 -> image v0.9.0. sops-secrets-operator#86, fixed by #90.
           sops_operator_ref: v0.9.0
           sops_operator_kustomize: "https://github.com/stuttgart-things/sops-secrets-operator/config/default"
+          sops_operator_namespace: sops-secrets-operator-system
+          sops_operator_overlay_dir: "/home/{{ ansible_user }}/.cache/sops-operator-overlay"
+          sops_age_key_data_key: age.agekey
+          # v0.9.0 (sops-secrets-operator#47) lets the operator hold one age key
+          # for resources that omit spec.decryption.keyRef. Enabling it here does
+          # NOT remove the per-namespace copies below: the capability charts
+          # still render an explicit keyRef, and a resource's own reference wins
+          # over the global default. Groundwork — see the PR.
+          sops_global_age_key_enabled: true
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.3.6"
           cert_manager_version: v1.21.0
@@ -621,9 +676,42 @@ playbooks:
                 sleep 5
               done
 
+          # Deployed through a thin local overlay rather than `apply -k <remote>`
+          # directly, so the manager's flags are part of the applied desired
+          # state. A `kubectl patch` after the apply would be undone by the next
+          # run — the same post-hoc mutation this playbook just dropped for the
+          # image pin (#1018).
+          - name: Create the sops-secrets-operator overlay dir
+            ansible.builtin.file:
+              path: "{{ sops_operator_overlay_dir }}"
+              state: directory
+              mode: "0755"
+
+          - name: Render the sops-secrets-operator kustomize overlay
+            ansible.builtin.copy:
+              dest: "{{ sops_operator_overlay_dir }}/kustomization.yaml"
+              mode: "0644"
+              content: |
+                ---
+                resources:
+                  - {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
+                {% if sops_global_age_key_enabled | bool %}
+                patches:
+                  - target:
+                      kind: Deployment
+                      name: sops-secrets-operator-controller-manager
+                    patch: |-
+                      - op: add
+                        path: /spec/template/spec/containers/0/args/-
+                        value: --global-age-key-secret={{ sops_operator_namespace }}/sops-age-key
+                      - op: add
+                        path: /spec/template/spec/containers/0/args/-
+                        value: --global-age-key-data-key={{ sops_age_key_data_key }}
+                {% endif %}
+
           - name: Deploy sops-secrets-operator (kustomize)
             ansible.builtin.command: >
-              kubectl apply -k {{ sops_operator_kustomize }}?ref={{ sops_operator_ref }}
+              kubectl apply -k {{ sops_operator_overlay_dir }}
               --kubeconfig {{ kubeconfig }}
 
           - name: Wait for sops-secrets-operator controller rollout


### PR DESCRIPTION
Follow-up to #1018. Wires up `--global-age-key-secret`, added in sops-secrets-operator v0.9.0 ([#47](https://github.com/stuttgart-things/sops-secrets-operator/issues/47)) — one age key the operator falls back to for resources that omit `spec.decryption.keyRef`.

## How

The operator is now deployed through a thin **local kustomize overlay** that references the same remote base and appends the flags, instead of `apply -k <remote>` directly:

```yaml
resources:
  - https://github.com/stuttgart-things/sops-secrets-operator/config/default?ref=v0.9.0
patches:
  - target: {kind: Deployment, name: sops-secrets-operator-controller-manager}
    patch: |-
      - op: add
        path: /spec/template/spec/containers/0/args/-
        value: --global-age-key-secret=sops-secrets-operator-system/sops-age-key
      …
```

Not a `kubectl patch` after the apply, deliberately: that would be undone by the next run and leave a window where the operator runs without its flags — the same post-hoc mutation #1018 just removed for the image pin. In an overlay the flags are part of the applied desired state.

Both plays go 22 → 24 tasks (create dir, render `kustomization.yaml`, apply). `sops-secrets-operator-system` joins `age_key_namespaces` so the key exists where the flag points. Toggle via `sops_global_age_key_enabled` (default `true`).

## Verified by building it, not by reasoning about it

For **both** plays and **both** toggle states, the rendered overlay was built with `kubectl kustomize`:

```
enabled=true    --metrics-bind-address=:8443
                --leader-elect
                --health-probe-bind-address=:8081
                --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
                --global-age-key-secret=sops-secrets-operator-system/sops-age-key
                --global-age-key-data-key=age.agekey

enabled=false   (base only — byte-identical to today)
```

Base args preserved, one container named `manager`, patched by name. Both plays also parse and pass `ansible-playbook --syntax-check`.

## What this deliberately does NOT do — read this bit

**It does not remove the per-namespace age-key copies, and it must not yet.**

I checked whether it could, by rendering the capability chart rather than assuming:

```console
$ helm template vspherevm oci://ghcr.io/stuttgart-things/charts/vspherevm --version 0.10.1 …
kind: InlineSopsSecret
  name: vsphere-creds-labul
    keyRef:
      name: sops-age-key
      key: age.agekey
```

The chart **always** emits an explicit `keyRef`, and by design a resource's own reference wins over the global default. So for everything this playbook installs, the global key is currently **inert** — deleting the `crossplane-system` / `tekton-ci` copies would break them immediately.

The payoff today is narrower than "the loop goes away": resources authored by hand, and any namespace added later, no longer need a copy.

Retiring the loop needs the charts to stop emitting `keyRef` first. That is a change in the charts repo and belongs there — worth a companion issue if we want it.

## Untested

Not run against a cluster. What is verified is the artifact the change produces (the built overlay above) and that the plays are structurally sound. The next real `kind_machinery` run against kind1 is the end-to-end proof — the thing to watch there is the manager pod coming up with the two new args and the existing capability CRs still reconciling from their own keyRefs.
