### PR TITLE
feat(container): read ansible-credentials from git (backend=sops-git)

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -105,7 +105,7 @@ playbooks:
           # over the global default. Groundwork — see the PR.
           sops_global_age_key_enabled: true
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
-          ansible_chart_version: "0.3.6"
+          ansible_chart_version: "0.4.0"
           cert_manager_version: v1.21.0
 
           # Per-environment capability charts. One Helm release per entry in
@@ -463,8 +463,8 @@ playbooks:
               helm upgrade --install ansible {{ charts_oci }}/ansible
               --version {{ ansible_chart_version }}
               --set environment={{ vsphere_env }}
-              --set sshCredentials.backend=sops
-              --set-file sshCredentials.sops.encryptedCredentials={{ secrets_dir }}/ansible-credentials.enc.yaml
+              --set sshCredentials.backend=sops-git
+              --set sshCredentials.sopsGit.repositoryRef.name={{ sops_git_repository_name }}
               -n crossplane-system --create-namespace
               --kubeconfig {{ kubeconfig }}
             become_user: "{{ ansible_user }}"
@@ -552,7 +552,7 @@ playbooks:
           # over the global default. Groundwork — see the PR.
           sops_global_age_key_enabled: true
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
-          ansible_chart_version: "0.3.6"
+          ansible_chart_version: "0.4.0"
           cert_manager_version: v1.21.0
 
           # Per-environment capability charts. One Helm release per entry in
@@ -845,8 +845,8 @@ playbooks:
             ansible.builtin.command: >
               helm upgrade --install ansible {{ charts_oci }}/ansible
               --version {{ ansible_chart_version }}
-              --set environment={{ vsphere_env }} --set sshCredentials.backend=sops
-              --set-file sshCredentials.sops.encryptedCredentials={{ secrets_dir }}/ansible-credentials.enc.yaml
+              --set environment={{ vsphere_env }} --set sshCredentials.backend=sops-git
+              --set sshCredentials.sopsGit.repositoryRef.name={{ sops_git_repository_name }}
               -n crossplane-system --create-namespace --kubeconfig {{ kubeconfig }}
             when: capabilities_enabled | bool
 


### PR DESCRIPTION
Completes step 3 of stuttgart-things/stuttgart-things#2405. The last capability still passing its encrypted blob in at deploy time stops doing so — the operator reads `secrets/ansible-credentials.enc.yaml` from the `GitRepository` the cluster already syncs.

Chart `0.3.6` → `0.4.0`, the version carrying the backend (stuttgart-things#2406, published to ghcr today).

## Nothing else was needed

- the `sops-git-secrets` precondition task and `SOPS_GIT_TOKEN` already landed with #1020;
- the chart's `sshCredentials.sopsGit.namespace` default is `crossplane-system`, which is exactly where that chart puts the `GitRepository`. (That default is load-bearing, not cosmetic: the operator resolves `sourceRef` only within the CR's own namespace, so the `SopsSecretManifest` has to sit next to the `GitRepository` and reach `tekton-ci` via `target.namespace`.)

## Verified

With the **exact argument string the task renders**, against the **published** chart rather than the working tree, for both plays:

```
kind: SopsSecretManifest    1
encryptedYAML occurrences:  0
```

plus `ClusterRole` / `ClusterRoleBinding` / `EnvironmentConfig` / `ManagedNamespace` unchanged. Both plays still pass `ansible-playbook --syntax-check`.

## Read this before the first run

`ansible-credentials` is consumed by the **Tekton pipelines** in `tekton-ci`. A silent credential change there does not look like a broken capability — it looks like failing pipeline runs, later, with a confusing error.

So `APPLIED=True` is not sufficient evidence. Compare a `sha256` of the decrypted values before and after the switch, as was done when migrating proxmoxvm.

## Untested

Not run against a cluster. What is verified is the artifact the change produces and that the plays are structurally sound.