### PR TITLE
feat(container): materialize the ownerless sops blobs from git

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -161,6 +161,18 @@ playbooks:
           sops_git_username: stuttgart-things
           # Read-only token with access to stuttgart_things_repo. Never commit.
           sops_git_token: "{{ lookup('env', 'SOPS_GIT_TOKEN') }}"
+          # Encrypted blobs in the secrets repo with no capability chart of
+          # their own — the capability charts each emit their own
+          # SopsSecretManifest, this list covers the rest. Both were applied by
+          # hand before they had an owner (stuttgart-things#2407).
+          # `namespace` is where the SECRET is written; the CR itself always
+          # goes next to the GitRepository, because the operator resolves
+          # sourceRef only within the CR's own namespace.
+          standalone_sops_secrets:
+            - name: vault
+              namespace: tekton-ci
+            - name: dapr-backstage-template-execution-vars
+              namespace: flux-system
 
           stuttgart_things_repo: "https://github.com/stuttgart-things/stuttgart-things.git"
           stuttgart_things_ref: main
@@ -435,6 +447,7 @@ playbooks:
                 --set git.url={{ stuttgart_things_repo }} \
                 --set git.auth.username={{ sops_git_username }} \
                 --set git.auth.password={{ sops_git_token }} \
+                {% for s in standalone_sops_secrets %}--set secrets[{{ loop.index0 }}].name={{ s.name }} --set secrets[{{ loop.index0 }}].namespace={{ s.namespace }} {% endfor %}\
                 -n crossplane-system --create-namespace \
                 --kubeconfig {{ kubeconfig }}
             become_user: "{{ ansible_user }}"
@@ -606,6 +619,18 @@ playbooks:
           sops_git_username: stuttgart-things
           # Read-only token with access to stuttgart_things_repo. Never commit.
           sops_git_token: "{{ lookup('env', 'SOPS_GIT_TOKEN') }}"
+          # Encrypted blobs in the secrets repo with no capability chart of
+          # their own — the capability charts each emit their own
+          # SopsSecretManifest, this list covers the rest. Both were applied by
+          # hand before they had an owner (stuttgart-things#2407).
+          # `namespace` is where the SECRET is written; the CR itself always
+          # goes next to the GitRepository, because the operator resolves
+          # sourceRef only within the CR's own namespace.
+          standalone_sops_secrets:
+            - name: vault
+              namespace: tekton-ci
+            - name: dapr-backstage-template-execution-vars
+              namespace: flux-system
 
           stuttgart_things_repo: "https://github.com/stuttgart-things/stuttgart-things.git"
           stuttgart_things_ref: main
@@ -821,6 +846,7 @@ playbooks:
                 --set git.url={{ stuttgart_things_repo }} \
                 --set git.auth.username={{ sops_git_username }} \
                 --set git.auth.password={{ sops_git_token }} \
+                {% for s in standalone_sops_secrets %}--set secrets[{{ loop.index0 }}].name={{ s.name }} --set secrets[{{ loop.index0 }}].namespace={{ s.namespace }} {% endfor %}\
                 -n crossplane-system --create-namespace \
                 --kubeconfig {{ kubeconfig }}
             when: capabilities_enabled | bool and sops_git_secrets_enabled | bool


### PR DESCRIPTION
Closes step 4 of stuttgart-things/stuttgart-things#2405 — the last one.

`tekton-ci/vault` and `flux-system/dapr-backstage-template-execution-vars` were `InlineSopsSecret`s applied **by hand**: no file in the secrets repo, no chart owning them, nothing that would notice if they drifted. Both blobs now live in the repo and the `sops-git-secrets` chart materializes them (stuttgart-things#2407, chart `0.2.0`).

Passed as a **vars list** rather than inline flags, so adding a blob later is one entry and not a task edit:

```yaml
standalone_sops_secrets:
  - name: vault
    namespace: tekton-ci
  - name: dapr-backstage-template-execution-vars
    namespace: flux-system
```

`namespace` there is where the **Secret** is written. The CR itself always goes next to the `GitRepository`, because the operator resolves `sourceRef` only within the CR's own namespace.

## Verified

With the exact flags the task renders, against the chart at `stuttgart-things` `main` (`ca21bee`):

```
SopsSecretManifest vault
  CR ns crossplane-system   path secrets/vault.enc.yaml                       target tekton-ci
SopsSecretManifest dapr-backstage-template-execution-vars
  CR ns crossplane-system   path secrets/dapr-…-vars.enc.yaml                 target flux-system
```

Both paths confirmed present at that ref.

The generated shell was checked with `bash -n` for the two-entry **and** the empty-list case — with an empty list the Jinja loop leaves a bare line continuation, which is valid, but worth proving rather than assuming. Both plays still pass `ansible-playbook --syntax-check`.

## After this

The machinery cluster has **no hand-applied sops secret left**: all five are declared in git and materialized by a chart.

| Secret | Owner |
|---|---|
| `vsphere-creds-lab{da,ul}` | `vspherevm` chart, `sops-git` |
| `proxmox-creds-labul` | `proxmoxvm` chart, `sops-git` |
| `ansible-credentials` | `ansible` chart, `sops-git` |
| `vault`, `dapr-…-vars` | `sops-git-secrets` chart `secrets:` list |

## Untested

Not run against a cluster. The real proof is the next `kind_machinery` run, and the check is unchanged: each resulting Secret must be **byte-identical** to what it replaces (`sha256` of the decrypted values before and after). `tekton-ci/vault` feeds Tekton pipelines and `dapr-…-vars` feeds Flux, so in both cases a silent change surfaces later as failing runs rather than as an obviously broken resource.