### PR TITLE
fix(container): install sops-git-secrets from OCI, not a private-repo clone

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -175,6 +175,9 @@ playbooks:
           sops_git_username: stuttgart-things
           # Read-only token with access to stuttgart_things_repo. Never commit.
           sops_git_token: "{{ lookup('env', 'SOPS_GIT_TOKEN') }}"
+          # sops-git-secrets is published to OCI (stuttgart-things#2407/#2408); install
+          # from there rather than cloning the private monorepo for its chart source.
+          sops_git_secrets_chart_version: "0.3.0"
           # Encrypted blobs in the secrets repo with no capability chart of
           # their own — the capability charts each emit their own
           # SopsSecretManifest, this list covers the rest. Both were applied by
@@ -450,21 +453,17 @@ playbooks:
           # chart emitting its own would collide on Helm ownership and clone the
           # same repo once per capability. Must exist before the charts below.
           - name: Deploy sops-git-secrets (GitRepository + read-only credential)
-            ansible.builtin.shell: |
-              set -e
-              rm -rf /tmp/stuttgart-things-baseline
-              git clone --depth 1 --branch {{ stuttgart_things_ref }} \
-                {{ stuttgart_things_repo }} /tmp/stuttgart-things-baseline
-              helm upgrade --install sops-git-secrets \
-                /tmp/stuttgart-things-baseline/crossplane/platform/baseline/sops-git-secrets \
-                --set git.name={{ sops_git_repository_name }} \
-                --set git.url={{ stuttgart_things_repo }} \
-                --set git.auth.username={{ sops_git_username }} \
-                --set git.auth.password={{ sops_git_token }} \
-                {% for s in standalone_sops_secrets %}--set secrets[{{ loop.index0 }}].name={{ s.name }} --set secrets[{{ loop.index0 }}].namespace={{ s.namespace }} {% endfor %}\
-                --set ageKeySecret.name={{ sops_age_key_ref_name }} \
-                -n crossplane-system --create-namespace \
-                --kubeconfig {{ kubeconfig }}
+            ansible.builtin.command: >
+              helm upgrade --install sops-git-secrets {{ charts_oci }}/sops-git-secrets
+              --version {{ sops_git_secrets_chart_version }}
+              --set git.name={{ sops_git_repository_name }}
+              --set git.url={{ stuttgart_things_repo }}
+              --set git.auth.username={{ sops_git_username }}
+              --set git.auth.password={{ sops_git_token }}
+              {% for s in standalone_sops_secrets %}--set secrets[{{ loop.index0 }}].name={{ s.name }} --set secrets[{{ loop.index0 }}].namespace={{ s.namespace }} {% endfor %}
+              --set ageKeySecret.name={{ sops_age_key_ref_name }}
+              -n crossplane-system --create-namespace
+              --kubeconfig {{ kubeconfig }}
             become_user: "{{ ansible_user }}"
             when: capabilities_enabled | bool and sops_git_secrets_enabled | bool
             no_log: true    # never echo the git token
@@ -653,6 +652,9 @@ playbooks:
           sops_git_username: stuttgart-things
           # Read-only token with access to stuttgart_things_repo. Never commit.
           sops_git_token: "{{ lookup('env', 'SOPS_GIT_TOKEN') }}"
+          # sops-git-secrets is published to OCI (stuttgart-things#2407/#2408); install
+          # from there rather than cloning the private monorepo for its chart source.
+          sops_git_secrets_chart_version: "0.3.0"
           # Encrypted blobs in the secrets repo with no capability chart of
           # their own — the capability charts each emit their own
           # SopsSecretManifest, this list covers the rest. Both were applied by
@@ -869,21 +871,17 @@ playbooks:
           # chart emitting its own would collide on Helm ownership and clone the
           # same repo once per capability. Must exist before the charts below.
           - name: Deploy sops-git-secrets (GitRepository + read-only credential)
-            ansible.builtin.shell: |
-              set -e
-              rm -rf /tmp/stuttgart-things-baseline
-              git clone --depth 1 --branch {{ stuttgart_things_ref }} \
-                {{ stuttgart_things_repo }} /tmp/stuttgart-things-baseline
-              helm upgrade --install sops-git-secrets \
-                /tmp/stuttgart-things-baseline/crossplane/platform/baseline/sops-git-secrets \
-                --set git.name={{ sops_git_repository_name }} \
-                --set git.url={{ stuttgart_things_repo }} \
-                --set git.auth.username={{ sops_git_username }} \
-                --set git.auth.password={{ sops_git_token }} \
-                {% for s in standalone_sops_secrets %}--set secrets[{{ loop.index0 }}].name={{ s.name }} --set secrets[{{ loop.index0 }}].namespace={{ s.namespace }} {% endfor %}\
-                --set ageKeySecret.name={{ sops_age_key_ref_name }} \
-                -n crossplane-system --create-namespace \
-                --kubeconfig {{ kubeconfig }}
+            ansible.builtin.command: >
+              helm upgrade --install sops-git-secrets {{ charts_oci }}/sops-git-secrets
+              --version {{ sops_git_secrets_chart_version }}
+              --set git.name={{ sops_git_repository_name }}
+              --set git.url={{ stuttgart_things_repo }}
+              --set git.auth.username={{ sops_git_username }}
+              --set git.auth.password={{ sops_git_token }}
+              {% for s in standalone_sops_secrets %}--set secrets[{{ loop.index0 }}].name={{ s.name }} --set secrets[{{ loop.index0 }}].namespace={{ s.namespace }} {% endfor %}
+              --set ageKeySecret.name={{ sops_age_key_ref_name }}
+              -n crossplane-system --create-namespace
+              --kubeconfig {{ kubeconfig }}
             when: capabilities_enabled | bool and sops_git_secrets_enabled | bool
             no_log: true    # never echo the git token
 


### PR DESCRIPTION
## The bug

The `sops-git-secrets` task cloned `github.com/stuttgart-things/stuttgart-things` to install the chart from a path:

```
git clone --depth 1 --branch main https://github.com/stuttgart-things/stuttgart-things.git /tmp/...
helm upgrade --install sops-git-secrets /tmp/.../crossplane/platform/baseline/sops-git-secrets ...
```

That repo is **private** (`visibility: private`), and the clone carries **no credential**. On a fresh machinery cluster — a freshly cloned VM with no cached git creds — the task fails at `git clone`. And it runs by **default** (`sops_git_secrets_enabled=true`). It only ever "worked" somewhere a git credential happened to be cached (a dev box that had authenticated before).

Found while preparing a fresh-VM validation run for the sops-git / global-key work: the clone is exactly what a genuinely fresh cluster exposes, and it has nothing to do with the sops-git logic we actually want to exercise.

## The fix

The chart is published (stuttgart-things/stuttgart-things#2407/#2408 → `oci://ghcr.io/stuttgart-things/charts/sops-git-secrets:0.3.0`), so install it **from OCI** and drop the clone entirely. `shell` → `command` (a single helm invocation — no shell needed). New var `sops_git_secrets_chart_version: "0.3.0"`.

**`git.url` still points at the private repo** — that is the `GitRepository` CR's *runtime* source, which the operator clones with the token in the auth Secret the chart creates. Only the *build-time* clone-for-chart-source is removed; the runtime path is unchanged.

## Verified

Rendered the exact command the task produces, for both global-key states and both plays, and ran it as `helm template` against the **published** `sops-git-secrets:0.3.0`:

```
Secret sops-git-credentials
GitRepository sops-secrets
SopsSecretManifest vault                      ns=crossplane-system target=tekton-ci   decryption=OMITTED (global key)
SopsSecretManifest dapr-...-vars              ns=crossplane-system target=flux-system decryption=OMITTED (global key)
```

Both plays pass `ansible-playbook --syntax-check`.

## Out of scope

The `provider-kubeconfig-vault` task has the **same** clone-a-private-repo pattern, but it is off by default (`vault_kubeconfigs_enabled=false`) and not on the sops path — left as-is here. Worth a follow-up if that chart is (or gets) published to OCI too.