### PR TITLE
fix(container): drop the 404ing manifest_urls default from kind_xplane_cluster

### DIFF
--- a/collections/container/kind.yaml
+++ b/collections/container/kind.yaml
@@ -60,8 +60,17 @@ playbooks:
             - https://github.com/stuttgart-things/helm/infra/crds/cert-manager
             - https://github.com/stuttgart-things/helm/cicd/crds/crossplane
 
-          manifest_urls:
-            - https://github.com/stuttgart-things/helm/cicd/crossplane-config
+          # Plain manifests to `kubectl apply -f`. Empty by default: the entry
+          # that used to live here,
+          #   https://github.com/stuttgart-things/helm/cicd/crossplane-config
+          # is not a directory in the helm repo — only
+          # `cicd/crossplane-config.yaml.gotmpl` exists, and that is a HELMFILE,
+          # which kubectl cannot apply. So the URL 404'd and this play failed
+          # every time it ran. kind_machinery does it correctly with
+          # `helmfile apply -f {{ helm_repo }}@cicd/crossplane-config.yaml.gotmpl`,
+          # so nothing is lost. Kept as an extension point for callers that do
+          # have real manifest URLs; the task below is guarded on length > 0.
+          manifest_urls: []
 
           helmfile_deployments:
             - location: "git::https://github.com/stuttgart-things/helm.git@infra/cilium.yaml.gotmpl"


### PR DESCRIPTION
## The bug

`kind_xplane_cluster`'s default `manifest_urls` is

```yaml
manifest_urls:
  - https://github.com/stuttgart-things/helm/cicd/crossplane-config
```

and the play runs `kubectl apply -f` on each entry. **That path is not a directory in the helm repo** — only `cicd/crossplane-config.yaml.gotmpl` exists, and that is a *helmfile*, which kubectl cannot apply. So the task fails every time the play runs:

```
failed: [10.31.103.27] (item=https://github.com/stuttgart-things/helm/cicd/crossplane-config) =>
  "cmd": "kubectl apply -f https://github.com/stuttgart-things/helm/cicd/crossplane-config --kubeconfig ...",
  "stderr": "error: unable to read URL \".../cicd/crossplane-config\", server reported 404 Not Found, status code=404",
  "rc": 1
```

`PLAY RECAP: ok=5 changed=2 failed=1`.

## The fix

Default to `[]`. Nothing is lost: **`kind_machinery` already applies that helmfile the correct way** — `helmfile apply -f {{ helm_repo }}@cicd/crossplane-config.yaml.gotmpl` — and it runs after `kind_xplane_cluster` in every bootstrap path we have.

The key is kept (as an empty list) rather than deleted, so callers with real manifest URLs keep the extension point; the task is guarded on `manifest_urls | length > 0`, so an empty list simply skips it.

`kustomize_urls` is untouched — `kubectl apply -k` does understand GitHub URLs, and those three entries apply cleanly (verified in the same run).

## How it surfaced

A fresh LabUL VM (`machinery-e2e`) driving `kind_xplane_cluster` through a Crossplane `AnsibleRun`. It had gone unnoticed because the earlier machinery validation ran with a local `cilium.yml` play; `kind_xplane_cluster` was substituted for it afterwards and never re-run — this is its first actual execution.

Verified: the play still parses and the guarded task is skipped with the empty default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91