### PR TITLE
chore(ci): bump dagger to v0.21.7

### DIFF
--- a/.github/workflows/dispatch-collection-build.yml
+++ b/.github/workflows/dispatch-collection-build.yml
@@ -18,7 +18,7 @@ on:
       dagger-version:
         description: DAGGER MODULE VERSION
         type: string
-        default: v0.20.6
+        default: v0.21.7
 
 jobs:
   collection-build:

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -53,6 +53,6 @@ jobs:
       environment-name: k8s
       collection-directory: ${{ matrix.collection-directory }}
       dagger-module-version: v0.109.0
-      dagger-version: v0.20.6
+      dagger-version: v0.21.7
       branch-name: ${{ github.event.pull_request.head.ref }}
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
Both collection-build workflows pinned dagger `v0.20.6`:

- `.github/workflows/pr-collection-build.yaml` — `dagger-version:`
- `.github/workflows/dispatch-collection-build.yml` — the input default

The PR build is currently failing inside the dagger container with apk errors:

```
ERROR: gdbm-1.26-r5: Permission denied
ERROR: sudo-1.9.17_p2-r7: Permission denied
2 errors; 180 MiB in 71 packages
Error: exit code: 2
```

alongside `No such image: registry.dagger.io/engine:v0.20.6` and the CLI's own `A new release of dagger is available: v0.20.6 → v0.21.7`.

**To be honest about causality:** I have not proven that this specific apk failure is the engine's fault — it may well be a transient runner issue. But running two minor versions behind while the engine image fails to resolve isn't worth debugging around.

This PR's own CI exercises the new version (workflows on a `pull_request` come from the PR branch).

Related: #1032 is red on exactly this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91