### PR TITLE
feat(container): add packer-release to machinery, bump packer-build to v0.4.1

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -202,6 +202,7 @@ playbooks:
           crossplane_configurations_ref: main
           environment_config_manifests:
             - cicd/packer-build/examples/environmentconfig.yaml
+            - cicd/packer-release/examples/environmentconfig.yaml
           platform_environment_config_manifests:
             - bootstrap/flux-init/examples/environment-config.yaml
             - bootstrap/flux-apps/examples/environment-config.yaml
@@ -220,7 +221,16 @@ playbooks:
               provider_crd: clusterproviderconfigs.proxmoxbpg.m.crossplane.io
             # Tekton-backed Packer builder — only provider-kubernetes, already up.
             - name: packer-build
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-build:v0.2.0"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-build:v0.4.1"
+            # Build -> test -> promote. Its dependsOn floor of packer-build
+            # >=v0.3.0 is why the pin above had to move: against v0.2.0 the
+            # promotion gate reads a `template-name` result that older
+            # packer-build does not surface, so the XR sits in phase=Building
+            # behind a successful build with no error. Pulls vm-provision
+            # (-> vsphere-vm, proxmox-vm, ansible-run) transitively; needs no
+            # provider beyond the ones already waited on above.
+            - name: packer-release
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-release:v0.2.2"
 
           # Fleet-manager half. `platform` pulls cni + flux-init via dependsOn.
           # flux-apps is listed explicitly because platform composes FluxApps
@@ -675,6 +685,7 @@ playbooks:
           crossplane_configurations_ref: main
           environment_config_manifests:
             - cicd/packer-build/examples/environmentconfig.yaml
+            - cicd/packer-release/examples/environmentconfig.yaml
           platform_environment_config_manifests:
             - bootstrap/flux-init/examples/environment-config.yaml
             - bootstrap/flux-apps/examples/environment-config.yaml
@@ -687,7 +698,16 @@ playbooks:
               package: "ghcr.io/stuttgart-things/crossplane-configurations/proxmoxvm:v0.4.0"
               provider_crd: clusterproviderconfigs.proxmoxbpg.m.crossplane.io
             - name: packer-build
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-build:v0.2.0"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-build:v0.4.1"
+            # Build -> test -> promote. Its dependsOn floor of packer-build
+            # >=v0.3.0 is why the pin above had to move: against v0.2.0 the
+            # promotion gate reads a `template-name` result that older
+            # packer-build does not surface, so the XR sits in phase=Building
+            # behind a successful build with no error. Pulls vm-provision
+            # (-> vsphere-vm, proxmox-vm, ansible-run) transitively; needs no
+            # provider beyond the ones already waited on above.
+            - name: packer-release
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-release:v0.2.2"
 
           platform_packages:
             - name: platform


### PR DESCRIPTION
A fresh machinery cluster could **build** images but not **promote** them: `packer-release` was missing from `machinery_packages` entirely, while the fleet (kind1) has been running it as `v0.2.2`. `packer-build` was pinned at `v0.2.0` — two minors behind kind1's `v0.4.1`.

## The two changes are coupled

`packer-release` declares `dependsOn: packer-build >=v0.3.0`, and that floor is **load-bearing**, per its own `crossplane.yaml`:

> The `>=v0.3.0` floor is LOAD-BEARING, not hygiene: the gate keys off the `template-name` PipelineRun result on the PackerBuild status, which v0.2.0 and earlier do not surface. Against an older packer-build the gate never opens and the XR sits in phase=Building with a successful build behind it — **a failure mode with no error message.**

So adding `packer-release` on top of the old pin would have shipped precisely that silent hang. The bump is a prerequisite, not cleanup.

## Details

- `packer-release` needs no `provider_crd` wait: provider-kubernetes is already up, and it pulls `vm-provision` (→ `vsphere-vm`, `proxmox-vm`, `ansible-run`) transitively, whose providers are already waited on above it.
- `cicd/packer-release/examples/environmentconfig.yaml` added next to the packer-build one.
- Both profiles updated — `kind_machinery_profile` and `kind_machinery`.

Verified: both plays still parse and each resolves to `[vspherevm, proxmoxvm, packer-build, packer-release]` with 2 EnvironmentConfig manifests.

Found while reviewing what the machinery bootstrap actually installs, after an AnsibleRun-driven e2e on a fresh LabUL cluster (crossplane-configurations#148/#149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91