### PR TITLE
feat(container): add cluster-backup to machinery (package + EnvironmentConfig)

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -203,6 +203,7 @@ playbooks:
           environment_config_manifests:
             - cicd/packer-build/examples/environmentconfig.yaml
             - cicd/packer-release/examples/environmentconfig.yaml
+            - cicd/cluster-backup/examples/environmentconfig.yaml
           platform_environment_config_manifests:
             - bootstrap/flux-init/examples/environment-config.yaml
             - bootstrap/flux-apps/examples/environment-config.yaml
@@ -231,6 +232,16 @@ playbooks:
             # provider beyond the ones already waited on above.
             - name: packer-release
               package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-release:v0.2.2"
+            # Scheduled encrypted state export to an OCI registry. Only
+            # provider-kubernetes (already up), like the packer packages, so no
+            # provider_crd wait. Installing the package + its EnvironmentConfig
+            # makes the capability available; a running backup additionally
+            # needs the backup-registry push Secret and, on a scoped provider
+            # SA, the provider-kubernetes RBAC from the Configuration's README
+            # (fleet GitOps, same place as provider-kubernetes-flux) - neither
+            # is required just to install this.
+            - name: cluster-backup
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster-backup:v0.1.0"
 
           # Fleet-manager half. `platform` pulls cni + flux-init via dependsOn.
           # flux-apps is listed explicitly because platform composes FluxApps
@@ -686,6 +697,7 @@ playbooks:
           environment_config_manifests:
             - cicd/packer-build/examples/environmentconfig.yaml
             - cicd/packer-release/examples/environmentconfig.yaml
+            - cicd/cluster-backup/examples/environmentconfig.yaml
           platform_environment_config_manifests:
             - bootstrap/flux-init/examples/environment-config.yaml
             - bootstrap/flux-apps/examples/environment-config.yaml
@@ -708,6 +720,16 @@ playbooks:
             # provider beyond the ones already waited on above.
             - name: packer-release
               package: "ghcr.io/stuttgart-things/crossplane-configurations/packer-release:v0.2.2"
+            # Scheduled encrypted state export to an OCI registry. Only
+            # provider-kubernetes (already up), like the packer packages, so no
+            # provider_crd wait. Installing the package + its EnvironmentConfig
+            # makes the capability available; a running backup additionally
+            # needs the backup-registry push Secret and, on a scoped provider
+            # SA, the provider-kubernetes RBAC from the Configuration's README
+            # (fleet GitOps, same place as provider-kubernetes-flux) - neither
+            # is required just to install this.
+            - name: cluster-backup
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster-backup:v0.1.0"
 
           platform_packages:
             - name: platform


### PR DESCRIPTION
Makes `cluster-backup` a machinery capability alongside vspherevm / proxmoxvm / packer-*, exactly like packer-release (#1035). Both profiles (`kind_machinery_profile` and `kind_machinery`) get:

- `cluster-backup:v0.1.0` in `machinery_packages` — no `provider_crd` wait, since like the packer packages it pulls only provider-kubernetes (already up);
- `cicd/cluster-backup/examples/environmentconfig.yaml` in `environment_config_manifests`.

## Scope — honest boundary

This **installs and configures** the capability. It does **not** create a `ClusterBackup` XR and does not make a backup run — same as packer-release installs the package without running a promotion. Two things are still required before a backup actually pushes, and **neither is needed to install**:

1. The `backup-registry` `dockerconfigjson` Secret (push credentials) in the pipeline namespace.
2. On a **scoped** provider-kubernetes SA — which fresh machinery clusters have, verified on kind1 — the provider-kubernetes RBAC documented in the [cluster-backup README](https://github.com/stuttgart-things/crossplane-configurations/tree/main/cicd/cluster-backup#cluster-preconditions). cluster-backup composes CronJobs and RBAC objects, which the default provider SA cannot create (`forbidden`).

   That grant belongs in **fleet GitOps**, next to the existing `provider-kubernetes-flux` / `provider-kubernetes-remoteclusters` ClusterRoles — which are not defined in this play or the helm repo either. So it is documented here, deliberately **not** applied by this play: inventing a home for provider RBAC in the bootstrap play would be scope creep and likely the wrong layer.

## Verified

Both profiles parse and resolve `machinery_packages` to `[vspherevm, proxmoxvm, packer-build, packer-release, cluster-backup]` with 3 EnvironmentConfig manifests.

Depends on `cluster-backup:v0.1.0` being public on ghcr — it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91