### PR TITLE
feat(container): materialize backup-registry via sops-git on machinery

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -190,6 +190,12 @@ playbooks:
               namespace: tekton-ci
             - name: dapr-backstage-template-execution-vars
               namespace: flux-system
+            # ghcr push credential for the cluster-backup CronJob. Lands in
+            # crossplane-system (cluster-backup's default spec.namespace), as a
+            # kubernetes.io/dockerconfigjson Secret - the type is carried in the
+            # encrypted manifest, so the operator materializes it as-is.
+            - name: backup-registry
+              namespace: crossplane-system
 
           stuttgart_things_repo: "https://github.com/stuttgart-things/stuttgart-things.git"
           stuttgart_things_ref: main
@@ -688,6 +694,12 @@ playbooks:
               namespace: tekton-ci
             - name: dapr-backstage-template-execution-vars
               namespace: flux-system
+            # ghcr push credential for the cluster-backup CronJob. Lands in
+            # crossplane-system (cluster-backup's default spec.namespace), as a
+            # kubernetes.io/dockerconfigjson Secret - the type is carried in the
+            # encrypted manifest, so the operator materializes it as-is.
+            - name: backup-registry
+              namespace: crossplane-system
 
           stuttgart_things_repo: "https://github.com/stuttgart-things/stuttgart-things.git"
           stuttgart_things_ref: main


### PR DESCRIPTION
Adds `backup-registry` to `standalone_sops_secrets` in both machinery profiles, so the sops-secrets-operator materializes it from `secrets/backup-registry.enc.yaml` (already committed to the monorepo) — the same sops-git path as `vault` and `dapr`.

- Lands in `crossplane-system` (cluster-backup's default `spec.namespace`).
- Materializes as `kubernetes.io/dockerconfigjson` — the type is in the encrypted manifest, so the operator applies it verbatim and the cluster-backup CronJob finds the `.dockerconfigjson` key it mounts.

This is the ghcr push credential from crossplane-configurations #150/#151, now delivered from git instead of created by hand — closing the precondition the cluster-backup machinery integration (#1036) left open.

Verified both profiles resolve `standalone_sops_secrets` to `[vault/tekton-ci, dapr…/flux-system, backup-registry/crossplane-system]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91