### PR TITLE
feat(container): deploy the cluster-backup capability chart on machinery

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -114,6 +114,7 @@ playbooks:
           sops_age_key_ref_name: "{{ '' if sops_global_age_key_enabled | bool else 'sops-age-key' }}"
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.5.0"
+          cluster_backup_chart_version: "0.1.0"
           cert_manager_version: v1.21.0
 
           # Per-environment capability charts. One Helm release per entry in
@@ -209,7 +210,8 @@ playbooks:
           environment_config_manifests:
             - cicd/packer-build/examples/environmentconfig.yaml
             - cicd/packer-release/examples/environmentconfig.yaml
-            - cicd/cluster-backup/examples/environmentconfig.yaml
+            # cluster-backup's EnvironmentConfig comes from its capability chart
+            # (deployed below), not applied raw — it also carries the provider RBAC.
           platform_environment_config_manifests:
             - bootstrap/flux-init/examples/environment-config.yaml
             - bootstrap/flux-apps/examples/environment-config.yaml
@@ -526,6 +528,18 @@ playbooks:
             become_user: "{{ ansible_user }}"
             when: capabilities_enabled | bool
 
+          # Provider-kubernetes RBAC (the backup composes CronJobs + RBAC) and
+          # the cluster-backup EnvironmentConfig. The push credential is the
+          # sops-git backup-registry blob, not set here.
+          - name: Deploy cluster-backup capability (single release)
+            ansible.builtin.command: >
+              helm upgrade --install cluster-backup {{ charts_oci }}/cluster-backup
+              --version {{ cluster_backup_chart_version }}
+              -n crossplane-system --create-namespace
+              --kubeconfig {{ kubeconfig }}
+            become_user: "{{ ansible_user }}"
+            when: capabilities_enabled | bool
+
           # ================================================================
           # 6) REMOTE-CLUSTER CREDENTIALS (optional) — the vault-kubeconfigs
           #    ClusterProviderConfig that RemoteCluster CRs reference. Chart
@@ -620,6 +634,7 @@ playbooks:
           sops_age_key_ref_name: "{{ '' if sops_global_age_key_enabled | bool else 'sops-age-key' }}"
           charts_oci: "oci://ghcr.io/stuttgart-things/charts"
           ansible_chart_version: "0.5.0"
+          cluster_backup_chart_version: "0.1.0"
           cert_manager_version: v1.21.0
 
           # Per-environment capability charts. One Helm release per entry in
@@ -709,7 +724,8 @@ playbooks:
           environment_config_manifests:
             - cicd/packer-build/examples/environmentconfig.yaml
             - cicd/packer-release/examples/environmentconfig.yaml
-            - cicd/cluster-backup/examples/environmentconfig.yaml
+            # cluster-backup's EnvironmentConfig comes from its capability chart
+            # (deployed below), not applied raw — it also carries the provider RBAC.
           platform_environment_config_manifests:
             - bootstrap/flux-init/examples/environment-config.yaml
             - bootstrap/flux-apps/examples/environment-config.yaml
@@ -962,6 +978,13 @@ playbooks:
               --set environment={{ vsphere_env }} --set sshCredentials.backend=sops-git
               --set sshCredentials.sopsGit.repositoryRef.name={{ sops_git_repository_name }}
               --set sshCredentials.sopsGit.ageKeySecret.name={{ sops_age_key_ref_name }}
+              -n crossplane-system --create-namespace --kubeconfig {{ kubeconfig }}
+            when: capabilities_enabled | bool
+
+          - name: Deploy cluster-backup capability (single release)
+            ansible.builtin.command: >
+              helm upgrade --install cluster-backup {{ charts_oci }}/cluster-backup
+              --version {{ cluster_backup_chart_version }}
               -n crossplane-system --create-namespace --kubeconfig {{ kubeconfig }}
             when: capabilities_enabled | bool
 


### PR DESCRIPTION
Promotes `cluster-backup` to a chart-based capability like ansible. Both machinery profiles now:

- **deploy the cluster-backup capability chart** (`charts/cluster-backup:0.1.0`, single release) — it emits the scoped provider-kubernetes **RBAC** the ClusterBackup Composition needs (it composes a CronJob + RBAC; a scoped provider SA is otherwise `forbidden`) and the `cluster-backup-defaults` **EnvironmentConfig**;
- **drop** `cicd/cluster-backup/examples/environmentconfig.yaml` from `environment_config_manifests` — the chart owns that EnvironmentConfig now, so raw-applying it too would be a second owner.

`machinery_packages` (the Configuration) and `standalone_sops_secrets` (`backup-registry`, the push credential, #1037) are unchanged.

This closes the provider-RBAC precondition that #1036 documented rather than solved.

## Proven on kind1

With the chart's group-bound RBAC, the composed Objects go `Synced/Ready`, and a real backup **pushed to ghcr** (`backups/kind1:h12` + `latest` + `d25`) using the sops-git `backup-registry` credential (username/password). Full chain green: sops-git secret → RBAC → XR → CronJob → encrypted push → round-trip restore verified earlier.

Requires `cluster-backup:0.1.0` on ghcr — published, public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91