### PR TITLE
fix(rke): store kubeconfig raw in vault, not base64

### DIFF
--- a/collections/rke/rke2.yaml
+++ b/collections/rke/rke2.yaml
@@ -100,6 +100,12 @@ playbooks:
             delegate_to: localhost
             when: replace_ip|bool
 
+          # Stored RAW, not base64. Vault KVv2 values are JSON strings and hold
+          # YAML fine, so the encoding was redundant — and provider-kubeconfig
+          # (RemoteCluster with source.type: vault) hands the value straight to
+          # clientcmd.RESTConfigFromKubeConfig with no decode step, so a base64
+          # blob fails to parse. Kept in sync with the container collection's
+          # upload_kubeconfig_vault, which was fixed the same way.
           - name: Write kubeconfig to vault using key value V2 engine
             community.hashi_vault.vault_write:
               auth_method: approle
@@ -110,7 +116,7 @@ playbooks:
               path: "{{ secret_path_kubeconfig }}/data/{{ cluster_name }}"
               data:
                 data:
-                  kubeconfig: "{{ lookup('ansible.builtin.file', kubeconfig_path|basename)|b64encode }}"
+                  kubeconfig: "{{ lookup('ansible.builtin.file', kubeconfig_path|basename) }}"
             delegate_to: localhost
 
   - name: rke2_workflow


### PR DESCRIPTION
`sthings.rke.upload_kubeconfig_vault` base64-encoded the kubeconfig before the `vault_write`:

```yaml
kubeconfig: "{{ lookup('ansible.builtin.file', kubeconfig_path|basename)|b64encode }}"
```

`provider-kubeconfig`'s `RemoteCluster` (`source.type: vault`) hands the stored value straight to `clientcmd.RESTConfigFromKubeConfig` with **no decode step**, so every entry this play produced is unusable for cluster adoption. The failure surfaces late — the ansible run reports success, and you only find out at the `ClusterProviderConfig`.

The container collection's `upload_kubeconfig_vault` was already fixed the same way and carries the reasoning in a comment. This brings rke in line and copies that comment, so the two do not drift apart again.

Vault KVv2 values are JSON strings and hold YAML fine, so the encoding bought nothing to begin with.

## How this surfaced

Publishing a k3s cluster's kubeconfig from a Crossplane `AnsibleRun` (stuttgart-things#2413). We had to reach for `sthings.container.upload_kubeconfig_vault` instead of the rke play that matches the distribution, purely because of this bug.

## Existing data

Entries previously written by this play stay base64 in Vault. They are rewritten on the next run of the play for that cluster; nothing migrates them automatically.

## After merge

Needs a new `sthings-rke` release (`Dispatch Collection Build` with `collection: rke`, or `task build-collection`) before consumers pick it up — `ansible-run-defaults` currently pins `sthings-rke-26.1.561`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WxdV8fXwBL6up38jCkAq6