### PR TITLE
fix: include the pipeline vars file in disk_cleanup

### DIFF
--- a/collections/baseos/cleanup.yaml
+++ b/collections/baseos/cleanup.yaml
@@ -76,6 +76,18 @@ playbooks:
               name: systemd-journald
               state: restarted
 
+        pre_tasks:
+          # Required when run through the stage-time execute-ansible pipeline (i.e. as
+          # sthings.baseos.disk_cleanup from an AnsibleRun XR): it hands its vars file
+          # in as -e path_to_vars_file=<workdir>/vars (no .yaml suffix) instead of
+          # --extra-vars, so without this include every spec.ansibleVarsFile entry is
+          # silently ignored and the play runs on its defaults. `tags: always` because
+          # the run may be tag-filtered; the guard keeps standalone runs working.
+          - name: Include vars
+            ansible.builtin.include_vars: "{{ path_to_vars_file }}.yaml"
+            when: path_to_vars_file is defined
+            tags: always
+
         tasks:
 
           # -------------------------------------------------------------- PREFLIGHT

--- a/plays/fleet-disk-cleanup.yaml
+++ b/plays/fleet-disk-cleanup.yaml
@@ -72,6 +72,18 @@
         name: systemd-journald
         state: restarted
 
+  pre_tasks:
+    # Required when run through the stage-time execute-ansible pipeline (i.e. as
+    # sthings.baseos.disk_cleanup from an AnsibleRun XR): it hands its vars file
+    # in as -e path_to_vars_file=<workdir>/vars (no .yaml suffix) instead of
+    # --extra-vars, so without this include every spec.ansibleVarsFile entry is
+    # silently ignored and the play runs on its defaults. `tags: always` because
+    # the run may be tag-filtered; the guard keeps standalone runs working.
+    - name: Include vars
+      ansible.builtin.include_vars: "{{ path_to_vars_file }}.yaml"
+      when: path_to_vars_file is defined
+      tags: always
+
   tasks:
 
     # -------------------------------------------------------------- PREFLIGHT


### PR DESCRIPTION
Follow-up to #1040.

The stage-time `execute-ansible` pipeline hands an AnsibleRun's `spec.ansibleVarsFile`
entries to the playbook as `-e path_to_vars_file=<workdir>/vars` (no `.yaml` suffix),
**not** as `--extra-vars` — only the SSH credentials come in via `--extra-vars`.
A playbook therefore has to include that file itself, as `pdns.yaml` and
`plays/prepare-env.yaml` already do.

`disk_cleanup` didn't, so every vars entry was silently dropped. Observed on
`run-disk-cleanup-u26-kind1`: `cleanup_runner_user+-sthings` never took effect and
the preflight reported `user=gh-runner (exists=False)`, which silently skipped all
user-scoped cleanup steps. The run still went green because the remaining values
happened to match the play defaults and `become: true` is set play-wide.

Guarded with `path_to_vars_file is defined` so standalone runs
(`ansible-playbook -i inv plays/fleet-disk-cleanup.yaml`) keep working, and tagged
`always` so tag-filtered runs still load it.

Verified against gh-dagger-runner-2 (`--check`):
- with `-e path_to_vars_file=.../vars` -> `user=sthings (exists=True, home=/home/sthings)`
- without -> `user=gh-runner`, unchanged standalone behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THKFZZvpVsqQoicFTRq7v1