### PR TITLE
fix(collections): declare galaxy metadata explicitly

### DIFF
--- a/collections/awx/collection.yaml
+++ b/collections/awx/collection.yaml
@@ -1,6 +1,19 @@
 ---
 name: awx
 namespace: sthings
+authors:
+  - patrick.hermann
+description: awx deployment, job templates and surveys
+license:
+  - Apache-2.0
+tags:
+  - awx
+  - ansible
+  - automation
+repository: https://github.com/stuttgart-things/ansible
+documentation: https://github.com/stuttgart-things/ansible
+homepage: https://github.com/stuttgart-things/ansible
+issues: https://github.com/stuttgart-things/ansible/issues
 requirements: |
   roles:
     - src: https://github.com/stuttgart-things/install-configure-docker.git

--- a/collections/baseos/collection.yaml
+++ b/collections/baseos/collection.yaml
@@ -3,6 +3,17 @@ name: baseos
 namespace: sthings
 authors:
   - patrick.hermann
+description: base operating system setup, users, binaries and filesystem management
+license:
+  - Apache-2.0
+tags:
+  - baseos
+  - linux
+  - setup
+repository: https://github.com/stuttgart-things/ansible
+documentation: https://github.com/stuttgart-things/ansible
+homepage: https://github.com/stuttgart-things/ansible
+issues: https://github.com/stuttgart-things/ansible/issues
 requirements: |
   roles:
     - src: https://github.com/stuttgart-things/download-install-binary.git

--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -1,6 +1,19 @@
 ---
 name: container
 namespace: sthings
+authors:
+  - patrick.hermann
+description: container runtimes, kubernetes distributions and helm profiles
+license:
+  - Apache-2.0
+tags:
+  - container
+  - kubernetes
+  - helm
+repository: https://github.com/stuttgart-things/ansible
+documentation: https://github.com/stuttgart-things/ansible
+homepage: https://github.com/stuttgart-things/ansible
+issues: https://github.com/stuttgart-things/ansible/issues
 requirements: |
   roles:
     - src: https://github.com/stuttgart-things/install-configure-docker.git

--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -1,6 +1,20 @@
 ---
 name: rke
 namespace: sthings
+authors:
+  - patrick.hermann
+description: rke2 and k3s cluster deployment and node configuration
+license:
+  - Apache-2.0
+tags:
+  - rke
+  - rke2
+  - k3s
+  - kubernetes
+repository: https://github.com/stuttgart-things/ansible
+documentation: https://github.com/stuttgart-things/ansible
+homepage: https://github.com/stuttgart-things/ansible
+issues: https://github.com/stuttgart-things/ansible/issues
 requirements: |
   roles:
     - src: https://github.com/stuttgart-things/deploy-configure-rke.git


### PR DESCRIPTION
## Problem

Every collection artifact released from this repo ships placeholder metadata in `MANIFEST.json`:

```json
"authors":     ["your name <example@domain.com>"],
"description": "your collection description",
"license":     ["GPL-2.0-or-later"],
"repository":  "http://example.com/repository"
```

This repo is **Apache-2.0** (see `LICENSE`), so every collection released for the past two years has declared **GPL-2.0-or-later**. That is a licensing misstatement shipped to every consumer, and a blocker for publishing to Galaxy.

The root cause is in the Dagger module, which hardcoded the `galaxy.yml` template instead of deriving it from `collection.yaml` — fixed in stuttgart-things/dagger#320. `collections/baseos/collection.yaml` had in fact declared `authors: [patrick.hermann]` all along; the module silently dropped it.

## Changes

All four `collection.yaml` files now declare `authors`, `description`, `license`, `tags`, `repository`, `documentation`, `homepage` and `issues`.

The module fix defaults the license to `Apache-2.0`, so this PR is not strictly required for correctness — but declaring the values here means the collections do not depend on module defaults for their own identity or license. A wrong-but-plausible default is exactly what caused this bug.

## Safe to merge on its own

No behaviour change until `DAGGER_ANSIBLE_MODULE_VERSION` is bumped past the module fix. Verified by running `run-collection-build-pipeline` with the **currently pinned `v0.109.0`** against the updated `collections/baseos`: it builds successfully (exit 0, artifact produced) and simply ignores the new keys, since `yaml.v3` is lenient about unknown fields.

## Verification

With the patched module, `collections/baseos` now produces:

```json
"namespace": "sthings",
"name": "baseos",
"authors": ["patrick.hermann"],
"tags": ["baseos", "linux", "setup"],
"description": "base operating system setup, users, binaries and filesystem management",
"license": ["Apache-2.0"],
"repository": "https://github.com/stuttgart-things/ansible",
"issues": "https://github.com/stuttgart-things/ansible/issues"
```

## Follow-up

1. Merge and release stuttgart-things/dagger#320
2. Bump `DAGGER_ANSIBLE_MODULE_VERSION` in `Taskfile.yaml:13` and both workflows (all pinned at `v0.109.0`; the module is at `v0.119.0`)
3. Re-release all four collections so the corrected license reaches consumers

Refs #1043, which tracks the remaining build/release findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
