### PR TITLE
fix: bump dagger ansible module to v0.120.0 and repair build-collection

### DIFF
--- a/.github/workflows/dispatch-collection-build.yml
+++ b/.github/workflows/dispatch-collection-build.yml
@@ -14,7 +14,7 @@ on:
       dagger-module-version:
         description: DAGGER MODULE VERSION
         type: string
-        default: v0.109.0
+        default: v0.120.0
       dagger-version:
         description: DAGGER MODULE VERSION
         type: string

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -52,7 +52,7 @@ jobs:
       runs-on: ubuntu-latest
       environment-name: k8s
       collection-directory: ${{ matrix.collection-directory }}
-      dagger-module-version: v0.109.0
+      dagger-module-version: v0.120.0
       dagger-version: v0.21.7
       branch-name: ${{ github.event.pull_request.head.ref }}
     secrets: inherit # pragma: allowlist secret

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,7 +10,7 @@ vars:
   BRANCH:
     sh: if [ $(git rev-parse --abbrev-ref HEAD) != "main" ]; then echo $(git rev-parse --abbrev-ref HEAD); else echo main ; fi
   DAGGER_ANSIBLE_MODULE: github.com/stuttgart-things/dagger/ansible
-  DAGGER_ANSIBLE_MODULE_VERSION: v0.109.0
+  DAGGER_ANSIBLE_MODULE_VERSION: v0.120.0
 
 # PRECONDITION TO CHECK IF THE VIRTUAL ENVIRONMENT IS ACTIVATED
 venv-precondition: &venv
@@ -73,16 +73,13 @@ tasks:
         echo "CHOOSE TO BE BUILD COLLECTION:"
         COLLECTION=$(gum choose {{ .ALL_COLLECTIONS }})
 
-        rm -rf {{ .WIP_DIR }}/*
-        dagger call -m {{ .DAGGER_ANSIBLE_MODULE }}@{{ .DAGGER_ANSIBLE_MODULE_VERSION }} init-collection --src {{ .SOURCE_COLLECTION_PATH }}/${COLLECTION} --progress plain export --path={{ .WIP_DIR }}
-        echo "INITIALIZED COLLECTION DIR IN: {{ .WIP_DIR }}/{{ .NAMESPACE }}/${COLLECTION}" && ls -lta {{ .WIP_DIR }}/{{ .NAMESPACE }}/${COLLECTION}
-
-        rm -rf {{ .BUILD_DIR }}/*
-        dagger call -m {{ .DAGGER_ANSIBLE_MODULE }}@{{ .DAGGER_ANSIBLE_MODULE_VERSION }} modify-role-includes --src {{ .WIP_DIR }}/{{ .NAMESPACE }}/${COLLECTION} --progress plain export --path {{ .BUILD_DIR }}
-        echo "MODIFIED COLLECTION IN: {{ .BUILD_DIR }}" && ls -lta {{ .BUILD_DIR }}
-
+        # SAME ENTRYPOINT AS CI (call-ansible-collection.yaml) SO THE LOCAL AND
+        # CI BUILD PATHS CANNOT DRIFT APART. THE PREVIOUS THREE-STEP FLOW WAS
+        # BROKEN: init-collection RETURNS A CollectionResult STRUCT, NOT A
+        # DIRECTORY, SO `export` FAILED WITH `unknown command "export"`
         rm -rf {{ .OUTPUT_DIR }}/*
-        dagger call -m {{ .DAGGER_ANSIBLE_MODULE }}@{{ .DAGGER_ANSIBLE_MODULE_VERSION }} build --src {{ .BUILD_DIR }} --progress plain export --path {{ .OUTPUT_DIR }}
+        dagger call -m {{ .DAGGER_ANSIBLE_MODULE }}@{{ .DAGGER_ANSIBLE_MODULE_VERSION }} run-collection-build-pipeline --src {{ .SOURCE_COLLECTION_PATH }}/${COLLECTION} --progress plain export --path {{ .OUTPUT_DIR }}
+        echo "BUILT COLLECTION IN: {{ .OUTPUT_DIR }}" && ls -lta {{ .OUTPUT_DIR }}
 
         ARTIFACT_PATH=$(ls {{ .OUTPUT_DIR }}/*tar.gz)
         RELEASE_TAG=$(basename "${ARTIFACT_PATH}" .tar.gz)
@@ -99,12 +96,8 @@ tasks:
         --tag ${RELEASE_TAG} \
         --title ${RELEASE_TAG}
     vars:
-      NAMESPACE: sthings
       SOURCE_COLLECTION_PATH: ./collections
-      COLLECTION_BUILD_DIR: /home/sthings/projects/ansible/ansible/collections
       COLLECTION_TMP_DIR: /tmp/ansible/collections
-      WIP_DIR: "{{ .COLLECTION_TMP_DIR }}/wip"
-      BUILD_DIR: "{{ .COLLECTION_TMP_DIR }}/build/"
       OUTPUT_DIR: "{{ .COLLECTION_TMP_DIR }}/artifacts/"
       ALL_COLLECTIONS:
         sh: ls {{ .SOURCE_COLLECTION_PATH }} | xargs -n1 printf '"%s" '


### PR DESCRIPTION
## Why

`v0.120.0` of the Dagger ansible module derives `galaxy.yml` from `collection.yaml` instead of hardcoding the template (stuttgart-things/dagger#320). Until this bump lands, collections keep shipping placeholder metadata — including **`license: GPL-2.0-or-later`** while this repo is Apache-2.0.

The version was pinned in three places; all three move together.

## Changes

- `v0.109.0` → `v0.120.0` in `Taskfile.yaml:13`, `.github/workflows/pr-collection-build.yaml` and `.github/workflows/dispatch-collection-build.yml`
- `build-collection` now calls `run-collection-build-pipeline` — the same entrypoint CI uses
- Drops `WIP_DIR`, `BUILD_DIR` and `NAMESPACE` (orphaned by the above), plus `COLLECTION_BUILD_DIR`, which was already unused and hardcoded to a developer home directory

## `task build-collection` was already broken

Worth calling out, because it looks like collateral in this diff and it is not.

The task called `init-collection … export --path=…`, but `InitCollection` returns a `CollectionResult` struct rather than a `Directory`, so Dagger rejects it:

```
Error: unknown command "export" for "dagger call init-collection"
```

Reproduced on the **previously pinned `v0.109.0`**, so this is a pre-existing break, not something the bump introduces — `InitCollection` has had that signature since at least `v0.108.0`. Only the CI path has been working.

Rather than port the three-step flow to `directory export`, this switches it to the single `run-collection-build-pipeline` call CI already uses, so the local and CI build paths cannot drift apart again. That is the todo under finding #8 of #1043.

## Verification

`run-collection-build-pipeline` run against `collections/baseos` with `v0.120.0`, both on this branch and with #1044's declared metadata applied. Both exit 0 and produce a valid artifact:

| field | this branch | with #1044 |
|---|---|---|
| `license` | `["Apache-2.0"]` | `["Apache-2.0"]` |
| `authors` | `["patrick.hermann"]` | `["patrick.hermann"]` |
| `description` | module default | declared value |
| `tags` | `[]` | `["baseos","linux","setup"]` |

Note `authors` — the module had been dropping the `authors: [patrick.hermann]` that `collections/baseos/collection.yaml` already declared.

**The bump alone fixes the license.** #1044 is polish on top, not a prerequisite; the two are independent and can merge in either order.

`Taskfile.yaml` and both workflow files re-validated as YAML. (`task --list` needs interactive trust for the remote `git.yaml` include, so it was not run.)

## Follow-up

Collections still need a re-release for the corrected license to reach consumers — they are pinned by URL in `requirements.yaml`, so nothing picks it up automatically.

Refs #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
