### PR TITLE
fix: bump collection pins to 26.2.675

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -18,7 +18,7 @@ collections:
     version: 6.2.1
   - name: kubernetes.core
     version: 6.5.0
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-25.4.506.tar.gz/sthings-awx-25.4.506.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.3.948.tar.gz/sthings-container-26.3.948.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.1.776.tar.gz/sthings-rke-26.1.776.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.3.1037.tar.gz/sthings-baseos-26.3.1037.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.2.675.tar.gz/sthings-awx-26.2.675.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.2.675.tar.gz/sthings-container-26.2.675.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.2.675.tar.gz/sthings-rke-26.2.675.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.2.675.tar.gz/sthings-baseos-26.2.675.tar.gz


### PR DESCRIPTION
## Why

The collection self-pins in `requirements.yaml` still pointed at artifacts built **before** the galaxy metadata fix. Anything installing from this file kept getting collections that declare `GPL-2.0-or-later` while this repo is Apache-2.0 — the releases were corrected, but nothing updates these pins automatically.

Molecule resolves its dependencies from this same file (`dependency: galaxy`, `requirements-file: requirements.yaml`, `force: True`), so the scenarios were force-installing stale published artifacts and testing those rather than anything current. That is finding #6 in #1043.

`awx` was the worst of it — `25.4.506` predates the current release line by over a year.

## Changes

| collection | before | after |
|---|---|---|
| `awx` | `25.4.506` | `26.2.675` |
| `container` | `26.3.948` | `26.2.675` |
| `rke` | `26.1.776` | `26.2.675` |
| `baseos` | `26.3.1037` | `26.2.675` |

`26.2.675` is the build from #1044, the first release carrying corrected metadata.

## Verification

Not just an HTTP reachability check — the four pinned URLs were installed with `ansible-galaxy collection install -r`:

```
sthings.awx:26.2.675 was installed successfully
sthings.container:26.2.675 was installed successfully
sthings.rke:26.2.675 was installed successfully
sthings.baseos:26.2.675 was installed successfully
```

All four report `license: ["Apache-2.0"]` and carry their vendored roles — baseos 7, container 5, rke 4, awx 1.

## One thing that looks wrong but isn't

The pins move **backwards** numerically: `baseos` goes `26.3.1037` → `26.2.675`, `container` `26.3.948` → `26.2.675`.

That is expected. The generated version is `YY.<weekday>.<minute-of-day>`, so it is not monotonic and drops every time the weekday resets. Exact URL pins are unaffected, but this is the concrete symptom behind finding #1 in #1043 — and the reason "just take the latest" would silently pick an older artifact here.

Refs #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
