### PR TITLE
feat(ci): release collections on merge to main, not on every PR

### DIFF
--- a/.github/workflows/dispatch-collection-build.yml
+++ b/.github/workflows/dispatch-collection-build.yml
@@ -11,34 +11,31 @@ on:
         type: string
         description: BRANCH NAME
         default: main
+      publish-release:
+        description: PUBLISH A GITHUB RELEASE FOR THE BUILT COLLECTION
+        type: boolean
+        default: false
       dagger-module-version:
         description: DAGGER MODULE VERSION
         type: string
         default: v0.120.0
       dagger-version:
-        description: DAGGER MODULE VERSION
+        description: DAGGER VERSION
         type: string
         default: v0.21.7
 
+# THE MANUAL RE-RELEASE PATH. SINCE RELEASES ONLY HAPPEN ON MERGE TO MAIN,
+# THIS IS HOW A COLLECTION IS REBUILT AND REPUBLISHED WITHOUT A CODE CHANGE -
+# FOR EXAMPLE AFTER A DAGGER MODULE BUMP CHANGES THE BUILT ARTIFACT
 jobs:
-  collection-build:
-    name: Collection Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Project
-        uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: '0'
-          ref: ${{ inputs.branch-name }}
-
-      - name: Build Collection
-        uses: dagger/dagger-for-github@v8.4.0
-        with:
-          version: ${{ inputs.dagger-version }}
-          verb: call
-          args: run-collection-build-pipeline --src collections/${{ inputs.collection }} --progress plain export --path=/tmp/build
-          module: github.com/stuttgart-things/dagger/ansible@${{ inputs.dagger-module-version }}
-
-      - name: List collection build
-        run: |
-          ls -lta /tmp/build
+  Build-Collection:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      environment-name: k8s
+      collection-directory: collections/${{ inputs.collection }}
+      dagger-module-version: ${{ inputs.dagger-module-version }}
+      dagger-version: ${{ inputs.dagger-version }}
+      branch-name: ${{ inputs.branch-name }}
+      publish-release: ${{ inputs.publish-release }}
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/main-collection-build.yaml
+++ b/.github/workflows/main-collection-build.yaml
@@ -1,0 +1,87 @@
+---
+name: Main Collection Build
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'collections/**'
+
+# NEVER CANCEL AN IN-FLIGHT RELEASE - A CANCELLED JOB CAN LEAVE A TAG
+# WITHOUT ITS ASSET. QUEUE INSTEAD SO MERGES RELEASE IN ORDER
+concurrency:
+  group: collection-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  Analyze-Collection-Config:
+    name: Analyze Collection Config
+    runs-on: ubuntu-latest
+    outputs:
+      collection_folders: ${{ steps.changed-files.outputs.collection_folders }}
+      has_changes: ${{ steps.changed-files.outputs.has_changes }}
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: '0'
+
+      - name: Get Collections Changed By Push
+        id: changed-files
+        run: |
+          set -euo pipefail
+
+          BEFORE="${{ github.event.before }}"
+
+          # before IS ZEROED ON A FIRST PUSH AND STALE AFTER A FORCE-PUSH,
+          # SO FALL BACK TO THE PARENT OF THE PUSHED COMMIT
+          if [ -z "${BEFORE}" ] \
+            || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "using parent commit as diff base"
+            BEFORE="${{ github.sha }}^"
+          fi
+
+          echo "DIFF RANGE: ${BEFORE}..${{ github.sha }}"
+
+          # KEEP ONLY collections/<name>/... AND REDUCE TO THE COLLECTION ROOT,
+          # SO A NESTED FILE STILL MAPS TO THE COLLECTION THAT OWNS IT
+          CHANGED_FOLDERS=$(git diff --name-only "${BEFORE}" "${{ github.sha }}" -- collections \
+            | awk -F/ 'NF>=3 && $1=="collections" {print $1"/"$2}' \
+            | sort -u)
+
+          echo "CHANGED COLLECTIONS: ${CHANGED_FOLDERS:-<none>}"
+
+          if [ -z "${CHANGED_FOLDERS}" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "collection_folders={\"collection-directory\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # SET CHANGED_FOLDERS AS MATRIX JSON
+          JSON_FOLDERS=$(printf '%s\n' "${CHANGED_FOLDERS}" \
+            | jq -R . \
+            | jq -sc '{"collection-directory": .}')
+
+          echo "${JSON_FOLDERS}"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "collection_folders=${JSON_FOLDERS}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+  Build-Collections:
+    needs: Analyze-Collection-Config
+    if: ${{ needs.Analyze-Collection-Config.outputs.has_changes == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.Analyze-Collection-Config.outputs.collection_folders) }}
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      environment-name: k8s
+      collection-directory: ${{ matrix.collection-directory }}
+      dagger-module-version: v0.120.0
+      dagger-version: v0.21.7
+      branch-name: ${{ github.ref_name }}
+      # THE ONLY PATH THAT PUBLISHES A RELEASE
+      publish-release: true
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -55,4 +55,7 @@ jobs:
       dagger-module-version: v0.120.0
       dagger-version: v0.21.7
       branch-name: ${{ github.event.pull_request.head.ref }}
+      # BUILD ONLY - THE ARTIFACT IS UPLOADED FOR REVIEW BUT NOT PUBLISHED.
+      # RELEASES ARE CUT BY main-collection-build.yaml ON MERGE TO MAIN
+      publish-release: false
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
Closes the biggest item in #1043 (finding #2).

## Problem

`Release-Collection` ran on the `pull_request` path, so **every PR touching `collections/**` published a public GitHub release from unreviewed branch code** — including branches later closed and never merged. Most of those PRs are Renovate bumps, and because collection dirs are derived per-file, a docs-only edit under `collections/` was enough to cut four releases.

The repo is at **800+ releases, 78 in the last 30 days.**

## Changes

**PR builds stop publishing.** `pr-collection-build.yaml` passes `publish-release: false`. Builds still run and still `upload-artifact`, so reviewers can download exactly what the PR produces — nothing is published.

**New `main-collection-build.yaml`** on `push: main`, `paths: collections/**`, passing `publish-release: true`. This is now the only path that cuts a release.

**`dispatch-collection-build.yml` becomes the manual re-release path.** It previously duplicated the build inline and only ran `ls` — it could not release. It now calls the same reusable workflow with `publish-release` as an input. Without this, once releases require a code change there is no way to republish after something like a Dagger module bump changes the artifact — which is exactly the operation we needed earlier today.

Depends on stuttgart-things/github-workflow-templates#122 (merged) for the `publish-release` input.

## The one piece of new logic

`Analyze-Collection-Config` reads changed files from `${{ github.event.pull_request.url }}/files`. **That field does not exist on `push`**, so the main workflow needs its own detection:

```bash
git diff --name-only "${BEFORE}" "${{ github.sha }}" -- collections \
  | awk -F/ 'NF>=3 && $1=="collections" {print $1"/"$2}' \
  | sort -u
```

Two deliberate details:

- `github.event.before` is zeroed on a first push and stale after a force-push, so it falls back to `${{ github.sha }}^` when it is missing or not a resolvable commit.
- Paths reduce to `collections/<name>` via `awk` rather than `dirname`. The PR job's `dirname` maps `collections/baseos/sub/x.yaml` to `collections/baseos/sub`, which is not a collection. This does not have that bug. I left the PR job alone to keep this diff focused — worth fixing separately.

Releases are serialised with a `concurrency` group and **never cancelled** — cancelling mid-release risks a tag without its asset.

## Verification

Detection logic run against real history in this repo:

| range | expected | got |
|---|---|---|
| `c56e9a9` (all four `collection.yaml`) | 4 collections | awx, baseos, container, rke |
| `507f8c9` (disk_cleanup) | baseos | baseos |
| `5b2da55` (`requirements.yaml` only) | none | none |
| `b520051..c56e9a9` (multi-commit) | 4 collections | awx, baseos, container, rke |

Edge cases checked: nested file → owning collection; `collections/README.md` → ignored; matrix JSON shape matches what `Build-Collections` already consumes, for both single and multiple entries.

All three workflows validated against the GitHub workflow schema (`check-jsonschema --builtin-schema vendor.github-workflows`).

## What to watch on merge

This PR touches only `.github/workflows/**`, so no collection build runs on it and the new behaviour is not exercised until it lands. **The first merge that touches `collections/**` is the real test** — it should produce exactly one release per changed collection.

If detection misfires, the failure mode is silent: no release rather than a bad one. `dispatch-collection-build.yml` with `publish-release: true` is the fallback, and reverting is a one-line flip of `publish-release`.

## Not included

Tag renaming (finding #3 — `.tar.gz` in the ref, which comes from `call-release-artifact.yaml` passing `--tag <artifact-name>`) is deliberately left out to keep this focused.

Refs #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
