### PR TITLE
fix(ci): correct changed-collection detection on PR builds

### DIFF
--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -16,6 +16,7 @@ jobs:
     environment: k8s
     outputs:
       collection_folders: ${{ steps.changed-files.outputs.collection_folders }}
+      has_changes: ${{ steps.changed-files.outputs.has_changes }}
     runs-on: ghr-ansible-in-cluster
     steps:
       - name: Get Modified Files by PullRequest
@@ -23,27 +24,66 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          FILES=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "${{ github.event.pull_request.url }}/files" | \
-          jq -r '.[].filename')
+          set -eu
 
-          echo "ALL_CHANGED_FILES=${FILES}"
-          ALL_CHANGED_FOLDERS=$(echo "$FILES" | tr ' ' '\n' | while read file; do dirname "$file"; done | sort | uniq | paste -sd ',')
+          CHANGED_FILES=$(mktemp)
+          PAGE=1
 
-          ALL_CHANGED_FOLDERS=$(echo "$ALL_CHANGED_FOLDERS" | tr ',' '\n' | grep '^collections/' | tr '\n' ',')
-          # Remove trailing comma if present
-          ALL_CHANGED_FOLDERS=${ALL_CHANGED_FOLDERS%,}
-          echo "ALL_CHANGED_FOLDERS=${ALL_CHANGED_FOLDERS}"
+          # THE FILES API PAGES AT 30 BY DEFAULT. A PR TOUCHING MORE THAN THAT
+          # WOULD SILENTLY DROP COLLECTIONS, SO WALK EVERY PAGE
+          while :; do
+            RESPONSE=$(curl -sS -w '\n%{http_code}' \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              "${{ github.event.pull_request.url }}/files?per_page=100&page=${PAGE}")
+
+            HTTP_CODE=$(printf '%s' "${RESPONSE}" | tail -n1)
+            BODY=$(printf '%s' "${RESPONSE}" | sed '$d')
+
+            # FAIL LOUDLY - AN API ERROR MUST NOT LOOK LIKE "NOTHING CHANGED"
+            if [ "${HTTP_CODE}" != "200" ]; then
+              echo "files api returned HTTP ${HTTP_CODE}"
+              echo "${BODY}"
+              exit 1
+            fi
+
+            BATCH=$(printf '%s' "${BODY}" | jq -r '.[].filename')
+            if [ -z "${BATCH}" ]; then
+              break
+            fi
+
+            printf '%s\n' "${BATCH}" >> "${CHANGED_FILES}"
+            PAGE=$((PAGE + 1))
+          done
+
+          echo "ALL_CHANGED_FILES:"
+          cat "${CHANGED_FILES}"
+
+          # REDUCE TO collections/<name>. dirname MAPPED A NESTED FILE TO A
+          # SUBDIRECTORY THAT IS NOT A COLLECTION, AND A FILE DIRECTLY UNDER
+          # collections/ TO A BARE "collections" THAT FELL THROUGH AS ""
+          ALL_CHANGED_FOLDERS=$(awk -F/ 'NF>=3 && $1=="collections" {print $1"/"$2}' \
+            "${CHANGED_FILES}" | sort -u)
+
+          echo "ALL_CHANGED_FOLDERS=${ALL_CHANGED_FOLDERS:-<none>}"
+
+          if [ -z "${ALL_CHANGED_FOLDERS}" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "collection_folders={\"collection-directory\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # SET CHANGED_FOLDERS AS MATRIX JSON
-          tf_folders=$(echo "\"${ALL_CHANGED_FOLDERS}\"" | sed 's/,/", "/g')
-          JSON_FOLDERS='{ "collection-directory": ['"${tf_folders}"'] }'
-          echo ${JSON_FOLDERS}
+          JSON_FOLDERS=$(printf '%s\n' "${ALL_CHANGED_FOLDERS}" \
+            | jq -R . \
+            | jq -sc '{"collection-directory": .}')
+
+          echo "${JSON_FOLDERS}"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "collection_folders=${JSON_FOLDERS}" >> "$GITHUB_OUTPUT"
 
   Build-Collections:
     needs: Analyze-Collection-Config
-    if: ${{ needs.Analyze-Collection-Config.outputs.collection_folders != '[]' && needs.Analyze-Collection-Config.outputs.collection_folders != '' }}
+    if: ${{ needs.Analyze-Collection-Config.outputs.has_changes == 'true' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.Analyze-Collection-Config.outputs.collection_folders) }}


### PR DESCRIPTION
Follow-up to #1047. While writing the push-side detection I found the PR-side job had a `dirname` bug — and looking closer, two more. All three are reproduced locally by running the existing shell against sample file lists.

## Defect 1 — `dirname` does not yield the collection

```
collections/baseos/sub/x.yaml  ->  { "collection-directory": ["collections/baseos/sub"] }
```

`collections/baseos/sub` is not a collection. The build would run against it and fail.

## Defect 2 — a file directly under `collections/` produces an empty matrix entry

`dirname collections/README.md` is `collections`, which the `grep '^collections/'` then drops, leaving an empty string:

```
collections/README.md  ->  { "collection-directory": [""] }
```

That **passes** the job guard, which only tested `!= '[]'` and `!= ''` and never anticipated this shape. The matrix then runs one build with an empty `--src`. A PR touching only `collections/README.md` was enough to trigger it.

## Defect 3 — no pagination, and no error check

The files API pages at 30 by default and the call did not paginate, so a PR touching more than 30 files silently dropped collections from the matrix.

Worse, `curl` output went straight to `jq` with no status check. A failed request yields an empty file list — **indistinguishable from "no collections changed"**, so the build would be skipped and the workflow would report success.

## Fix

- Paths reduce via `awk -F/ 'NF>=3 && $1=="collections" {print $1"/"$2}'`, the same expression `main-collection-build.yaml` uses, so both paths now agree
- Explicit `has_changes` output; `Build-Collections` gates on that instead of inspecting the JSON shape
- The API call walks every page at `per_page=100` and fails loudly on a non-200

## Verification

Logic, run against sample file lists:

| input | result |
|---|---|
| `collections/baseos/sub/x.yaml` | `["collections/baseos"]` |
| `collections/README.md` | `has_changes=false` |
| `collections/baseos/setup.yaml` + `collections/rke/k3s.yaml` | both, deduped |
| nested + duplicates within one collection | collapses to one entry |
| `requirements.yaml`, `Taskfile.yaml` | `has_changes=false` |

Against the live GitHub API:

- PR #1044 → all four collections; PR #1047 → none
- Forcing `per_page=1` against #1044 walks **4 pages** and still finds all 4 files, confirming the loop pages and terminates
- A 404 exits non-zero rather than reporting "no changes"

Schema-validated with `check-jsonschema --builtin-schema vendor.github-workflows`.

## Note

This PR touches only `.github/workflows/**`, so it does not trigger a collection build and cannot exercise itself. Behaviour is unchanged for the ordinary case — a PR editing files inside one or more collections resolves exactly as before.

Refs #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
