### PR TITLE
fix: build collections with a monotonic version

### DIFF
--- a/.github/workflows/dispatch-collection-build.yml
+++ b/.github/workflows/dispatch-collection-build.yml
@@ -18,7 +18,7 @@ on:
       dagger-module-version:
         description: DAGGER MODULE VERSION
         type: string
-        default: v0.120.0
+        default: v0.121.0
       dagger-version:
         description: DAGGER VERSION
         type: string

--- a/.github/workflows/main-collection-build.yaml
+++ b/.github/workflows/main-collection-build.yaml
@@ -79,7 +79,7 @@ jobs:
       runs-on: ubuntu-latest
       environment-name: k8s
       collection-directory: ${{ matrix.collection-directory }}
-      dagger-module-version: v0.120.0
+      dagger-module-version: v0.121.0
       dagger-version: v0.21.7
       branch-name: ${{ github.ref_name }}
       # THE ONLY PATH THAT PUBLISHES A RELEASE

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -92,7 +92,7 @@ jobs:
       runs-on: ubuntu-latest
       environment-name: k8s
       collection-directory: ${{ matrix.collection-directory }}
-      dagger-module-version: v0.120.0
+      dagger-module-version: v0.121.0
       dagger-version: v0.21.7
       branch-name: ${{ github.event.pull_request.head.ref }}
       # BUILD ONLY - THE ARTIFACT IS UPLOADED FOR REVIEW BUT NOT PUBLISHED.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,7 +10,7 @@ vars:
   BRANCH:
     sh: if [ $(git rev-parse --abbrev-ref HEAD) != "main" ]; then echo $(git rev-parse --abbrev-ref HEAD); else echo main ; fi
   DAGGER_ANSIBLE_MODULE: github.com/stuttgart-things/dagger/ansible
-  DAGGER_ANSIBLE_MODULE_VERSION: v0.120.0
+  DAGGER_ANSIBLE_MODULE_VERSION: v0.121.0
 
 # PRECONDITION TO CHECK IF THE VIRTUAL ENVIRONMENT IS ACTIVATED
 venv-precondition: &venv
@@ -77,8 +77,19 @@ tasks:
         # CI BUILD PATHS CANNOT DRIFT APART. THE PREVIOUS THREE-STEP FLOW WAS
         # BROKEN: init-collection RETURNS A CollectionResult STRUCT, NOT A
         # DIRECTORY, SO `export` FAILED WITH `unknown command "export"`
+
+        # SAME VERSION SCHEME AS CI - YY.MMDD.<COMMIT COUNT>. WITHOUT THIS THE
+        # MODULE FALLS BACK TO A NON-MONOTONIC CALENDAR VERSION
+        if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+          echo "repository is shallow - the commit count would be wrong"
+          exit 1
+        fi
+
+        COLLECTION_VERSION="$(date -u +%y).$(date -u +%-m%d).$(git rev-list --count HEAD)"
+        echo "COLLECTION VERSION: ${COLLECTION_VERSION}"
+
         rm -rf {{ .OUTPUT_DIR }}/*
-        dagger call -m {{ .DAGGER_ANSIBLE_MODULE }}@{{ .DAGGER_ANSIBLE_MODULE_VERSION }} run-collection-build-pipeline --src {{ .SOURCE_COLLECTION_PATH }}/${COLLECTION} --progress plain export --path {{ .OUTPUT_DIR }}
+        dagger call -m {{ .DAGGER_ANSIBLE_MODULE }}@{{ .DAGGER_ANSIBLE_MODULE_VERSION }} run-collection-build-pipeline --src {{ .SOURCE_COLLECTION_PATH }}/${COLLECTION} --version ${COLLECTION_VERSION} --progress plain export --path {{ .OUTPUT_DIR }}
         echo "BUILT COLLECTION IN: {{ .OUTPUT_DIR }}" && ls -lta {{ .OUTPUT_DIR }}
 
         ARTIFACT_PATH=$(ls {{ .OUTPUT_DIR }}/*tar.gz)


### PR DESCRIPTION
Closes finding #1 of #1043 — the last structural problem in the build pipeline.

## Problem

The module derived the version from the clock:

```go
minor := int(currentDate.Weekday())      // 0 = Sunday .. 6 = Saturday
patch := currentDate.Hour()*60 + currentDate.Minute()
```

So versions **drop every time the weekday resets**. This repo has already published two pairs of distinct artifacts under one version — `sthings-container-25.5.499` and `sthings-baseos-25.3.605` — and #1046 had to move its pins numerically *downward* (`26.3.1037` → `26.2.675`) to move *forward* in time.

## Changes

- Module bumped to **v0.121.0**, the first version accepting a caller-supplied version (stuttgart-things/dagger#322), across all four pins
- `Taskfile.yaml` computes `YY.MMDD.<commit count>` and passes `--version`

CI does the same in stuttgart-things/github-workflow-templates#124, using the same expression, so local and CI builds produce identical versions.

## Scheme

Today: `26.728.1151`.

| property | verified |
|---|---|
| Valid semver | three numeric parts |
| Above every published version | max is `26.6.1313` |
| Monotonic day → day | `26.728.1151` → `26.729.1152` |
| Monotonic month → month | `26.728.1151` → `26.801.1160` |
| Monotonic year → year | `26.1231.2000` → `27.101.2001` |

The minor carries ordering on its own, so the patch cannot cause a regression — and being a commit count, it ties a release to an exact commit rather than to a wall-clock minute.

## Shallow clones fail rather than guess

The commit count is only correct on a full clone; a shallow one would silently build a version *below* the last release. The task now fails instead. Same lesson as #1048 — the previous bug here failed toward green, and a wrong version would too.

## Re-releasing the same commit is refused

Because the version comes from the commit, an existing tag means this source was already released. stuttgart-things/github-workflow-templates#124 fails with a readable message rather than colliding. It sits in the release path, so PR rebuilds are unaffected.

If you genuinely need to republish — say a module bump changes the artifact — that bump is itself a commit, so the count advances and the version is new.

## Verification

`v0.121.0` with `--version 26.728.1151` against `collections/baseos` produces that version in `MANIFEST.json` and artifact `sthings-baseos-26.728.1151.tar.gz`. Omitting the flag still builds, falling back to the old generator with a warning — so the change is backward compatible.

Taskfile and all workflows re-validated.

## Order

stuttgart-things/github-workflow-templates#124 should land first, so the first merge here builds through CI with the version already being passed.

Refs #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY