### PR TITLE
fix(ci): run molecule against the built collection, not the last release

### DIFF
--- a/.github/workflows/nightly-molecule-awx.yaml
+++ b/.github/workflows/nightly-molecule-awx.yaml
@@ -1,0 +1,69 @@
+---
+name: Nightly Molecule AWX
+on:
+  schedule:
+    # 02:30 UTC, OFF THE HOUR TO AVOID THE SCHEDULER'S BUSIEST MINUTE
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+    inputs:
+      branch-name:
+        description: BRANCH NAME
+        type: string
+        default: main
+
+# THE awx SCENARIO IS NOT A PR GATE. molecule/awx/prepare.yml CREATES A KIND
+# CLUSTER, DEPLOYS AWX, WAITS FOR IT TO BE READY AND NEEDS VAULT CREDENTIALS -
+# far TOO SLOW AND TOO SECRET-DEPENDENT TO RUN ON EVERY PULL REQUEST, AND ON
+# pull_request IT WOULD EXPOSE THOSE SECRETS THE WAY FINDING #9 DESCRIBES.
+#
+# IT RUNS AGAINST THE PUBLISHED COLLECTIONS PINNED IN requirements.yaml, SO IT
+# TESTS WHAT CONSUMERS ACTUALLY INSTALL RATHER THAN AN UNMERGED BUILD.
+concurrency:
+  group: nightly-molecule-awx
+  cancel-in-progress: false
+
+jobs:
+  Molecule-AWX:
+    name: Molecule AWX
+    runs-on: ubuntu-latest
+    environment: k8s
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ inputs.branch-name || 'main' }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Molecule
+        run: |
+          set -eu
+          pip install --upgrade pip setuptools
+          pip install 'molecule' 'molecule-docker' netaddr
+          molecule --version
+        shell: bash
+
+      - name: Install Collections
+        run: |
+          set -eu
+          ansible-galaxy collection install -r requirements.yaml
+          ansible-galaxy collection list | grep sthings
+        shell: bash
+
+      - name: Molecule Test
+        env:
+          MOLECULE_DOCKER_COMMAND: /lib/systemd/systemd
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+          VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+        run: molecule test -s awx
+        shell: bash
+
+      - name: Molecule Destroy
+        if: always()
+        continue-on-error: true
+        run: molecule destroy -s awx
+        shell: bash

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -17,6 +17,8 @@ jobs:
     outputs:
       collection_folders: ${{ steps.changed-files.outputs.collection_folders }}
       has_changes: ${{ steps.changed-files.outputs.has_changes }}
+      molecule_folders: ${{ steps.changed-files.outputs.molecule_folders }}
+      has_molecule: ${{ steps.changed-files.outputs.has_molecule }}
     runs-on: ghr-ansible-in-cluster
     steps:
       - name: Get Modified Files by PullRequest
@@ -68,7 +70,9 @@ jobs:
 
           if [ -z "${ALL_CHANGED_FOLDERS}" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "has_molecule=false" >> "$GITHUB_OUTPUT"
             echo "collection_folders={\"collection-directory\":[]}" >> "$GITHUB_OUTPUT"
+            echo "molecule_folders={\"collection-directory\":[]}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -80,6 +84,28 @@ jobs:
           echo "${JSON_FOLDERS}"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "collection_folders=${JSON_FOLDERS}" >> "$GITHUB_OUTPUT"
+
+          # ONLY THESE SCENARIOS GATE A PR. awx NEEDS A KIND CLUSTER, AN AWX
+          # DEPLOY AND VAULT CREDENTIALS, SO IT RUNS NIGHTLY INSTEAD
+          # (nightly-molecule-awx.yaml). rke IS SYNTAX-ONLY AND RUNS BELOW
+          MOLECULE_FOLDERS=$(printf '%s\n' "${ALL_CHANGED_FOLDERS}" \
+            | grep -E '^collections/(baseos|container|rke)$' || true)
+
+          echo "MOLECULE_FOLDERS=${MOLECULE_FOLDERS:-<none>}"
+
+          if [ -z "${MOLECULE_FOLDERS}" ]; then
+            echo "has_molecule=false" >> "$GITHUB_OUTPUT"
+            echo "molecule_folders={\"collection-directory\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          JSON_MOLECULE=$(printf '%s\n' "${MOLECULE_FOLDERS}" \
+            | jq -R . \
+            | jq -sc '{"collection-directory": .}')
+
+          echo "${JSON_MOLECULE}"
+          echo "has_molecule=true" >> "$GITHUB_OUTPUT"
+          echo "molecule_folders=${JSON_MOLECULE}" >> "$GITHUB_OUTPUT"
 
   Build-Collections:
     needs: Analyze-Collection-Config
@@ -99,3 +125,89 @@ jobs:
       # RELEASES ARE CUT BY main-collection-build.yaml ON MERGE TO MAIN
       publish-release: false
     secrets: inherit # pragma: allowlist secret
+
+  Molecule-Test:
+    name: Molecule
+    needs:
+      - Analyze-Collection-Config
+      - Build-Collections
+    if: ${{ needs.Analyze-Collection-Config.outputs.has_molecule == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.Analyze-Collection-Config.outputs.molecule_folders) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Resolve Scenario
+        id: scenario
+        run: |
+          set -eu
+          SCENARIO=$(basename "${{ matrix.collection-directory }}")
+          echo "SCENARIO: ${SCENARIO}"
+          echo "scenario=${SCENARIO}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Molecule
+        run: |
+          set -eu
+          pip install --upgrade pip setuptools
+          pip install 'molecule' 'molecule-docker' netaddr
+          molecule --version
+        shell: bash
+
+      - name: Download Built Collection
+        uses: actions/download-artifact@v7.0.1
+        with:
+          # THE ARTIFACT IS NAMED sthings-<collection>-<version>.tar.gz AND THE
+          # VERSION IS NOT KNOWN HERE, SO MATCH ON THE PREFIX
+          pattern: sthings-${{ steps.scenario.outputs.scenario }}-*
+          merge-multiple: true
+          path: /tmp/collection
+
+      - name: Install Collections
+        run: |
+          set -eu
+
+          # PUBLISHED PINS FIRST - THEY PROVIDE THE OTHER sthings COLLECTIONS A
+          # SCENARIO IMPORTS. molecule/container/converge.yaml, FOR ONE, PULLS IN
+          # sthings.baseos.users AS WELL AS sthings.container.tools
+          ansible-galaxy collection install -r requirements.yaml
+
+          # THEN THE BUILD UNDER TEST, OVERWRITING ITS PUBLISHED COUNTERPART.
+          # WITHOUT THIS THE SUITE TESTS THE LAST RELEASE, NOT THIS PR
+          ARTIFACT=$(ls /tmp/collection/*.tar.gz | head -n 1)
+          echo "COLLECTION UNDER TEST: ${ARTIFACT}"
+          ansible-galaxy collection install --force "${ARTIFACT}"
+
+          ansible-galaxy collection list | grep sthings
+        shell: bash
+
+      - name: Molecule Test
+        env:
+          MOLECULE_DOCKER_COMMAND: /lib/systemd/systemd
+        run: molecule test -s ${{ steps.scenario.outputs.scenario }}
+        shell: bash
+
+      # INFORMATIONAL. THESE PLAYBOOKS HAVE NEVER BEEN HELD TO IDEMPOTENCE, SO A
+      # FAILURE HERE REPORTS RATHER THAN BLOCKS. rke NEVER CONVERGES, SO IT HAS
+      # NO INSTANCE TO RE-RUN AGAINST
+      - name: Molecule Idempotence (informational)
+        if: ${{ steps.scenario.outputs.scenario != 'rke' }}
+        continue-on-error: true
+        run: molecule idempotence -s ${{ steps.scenario.outputs.scenario }}
+        shell: bash
+
+      - name: Molecule Destroy
+        if: always()
+        continue-on-error: true
+        run: molecule destroy -s ${{ steps.scenario.outputs.scenario }}
+        shell: bash

--- a/molecule/baseos/molecule.yml
+++ b/molecule/baseos/molecule.yml
@@ -4,7 +4,7 @@ dependency:
   enabled: True
   options:
     ignore-certs: True
-    requirements-file: requirements.yaml
+    requirements-file: molecule/requirements.yaml
     ignore-errors: false
     force: True
 

--- a/molecule/container/molecule.yml
+++ b/molecule/container/molecule.yml
@@ -4,7 +4,7 @@ dependency:
   enabled: True
   options:
     ignore-certs: True
-    requirements-file: requirements.yaml
+    requirements-file: molecule/requirements.yaml
     ignore-errors: false
     force: True
 

--- a/molecule/requirements.yaml
+++ b/molecule/requirements.yaml
@@ -1,0 +1,32 @@
+---
+# UPSTREAM COLLECTIONS ONLY.
+#
+# molecule RESOLVES ITS dependency STEP FROM THIS FILE WITH force: True. THE
+# sthings.* COLLECTIONS ARE DELIBERATELY ABSENT: LISTING THEM HERE WOULD LET
+# THAT STEP OVERWRITE THE FRESHLY BUILT COLLECTION UNDER TEST WITH THE LAST
+# PUBLISHED ONE, WHICH IS EXACTLY THE BUG THIS SPLIT FIXES.
+#
+# THE sthings.* COLLECTIONS ARE INSTALLED BEFORE molecule RUNS:
+#   1. ../requirements.yaml            -> published pins, for dependencies
+#   2. the built .tar.gz, with --force -> the collection actually under test
+#
+# ../requirements.yaml stays the consumer-facing pin file and is not used here.
+collections:
+  - name: ansible.netcommon
+    version: 8.6.1
+  - name: ansible.posix
+    version: 2.2.2
+  - name: awx.awx
+    version: 24.6.1
+  - name: community.crypto
+    version: 3.3.0
+  - name: community.docker
+    version: 5.2.1
+  - name: community.general
+    version: 13.2.0
+  - name: community.hashi_vault
+    version: 7.1.0
+  - name: community.vmware
+    version: 6.2.1
+  - name: kubernetes.core
+    version: 6.5.0

--- a/molecule/rke/converge.yaml
+++ b/molecule/rke/converge.yaml
@@ -1,0 +1,24 @@
+---
+# NEVER CONVERGED - THIS SCENARIO STOPS AT syntax (SEE molecule.yml). THE
+# IMPORTS EXIST SO ansible-playbook --syntax-check PARSES EVERY rke PLAYBOOK
+# IN THE BUILT COLLECTION AND RESOLVES ITS INCLUDES.
+- name: Syntax check rke2 cluster deployment
+  ansible.builtin.import_playbook: sthings.rke.rke2_cluster
+
+- name: Syntax check rke2 node configuration
+  ansible.builtin.import_playbook: sthings.rke.rke2
+
+- name: Syntax check rke2 workflow
+  ansible.builtin.import_playbook: sthings.rke.rke2_workflow
+
+- name: Syntax check rke2 api token
+  ansible.builtin.import_playbook: sthings.rke.api_token
+
+- name: Syntax check kubeconfig upload
+  ansible.builtin.import_playbook: sthings.rke.upload_kubeconfig_vault
+
+- name: Syntax check k3s cluster deployment
+  ansible.builtin.import_playbook: sthings.rke.k3s_cluster
+
+- name: Syntax check k3s node configuration
+  ansible.builtin.import_playbook: sthings.rke.k3s

--- a/molecule/rke/molecule.yml
+++ b/molecule/rke/molecule.yml
@@ -1,4 +1,13 @@
 ---
+# SYNTAX-ONLY SCENARIO.
+#
+# THE rke PLAYBOOKS DEPLOY REAL CLUSTERS, WHICH IS TOO HEAVY FOR A PR GATE, SO
+# THIS SEQUENCE STOPS AT syntax - NO CONTAINER IS CREATED AND NOTHING CONVERGES.
+# IT STILL CATCHES THE FAILURE MODE THAT USED TO REACH PRODUCTION: A PLAYBOOK
+# THAT DOES NOT PARSE, OR A src:/include: THAT DOES NOT RESOLVE IN THE BUILT
+# COLLECTION.
+#
+# GROWING THIS INTO A REAL CONVERGE NEEDS A CLUSTER-CAPABLE ENVIRONMENT.
 dependency:
   name: galaxy
   enabled: True
@@ -10,33 +19,22 @@ dependency:
 
 driver:
   name: docker
+
 platforms:
   - name: ubuntu24
     image: geerlingguy/docker-ubuntu2404-ansible@sha256:129f93fb11c00d2452f541fc926234a2ecf7957d7348fb07832bd0bf6973f503
-    command: ${MOLECULE_DOCKER_COMMAND:-""} #sudo apt update -y && sudo apt upgrade -y
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
     pre_build_image: true
+
 provisioner:
   name: ansible
-  options:
-    vvv: true
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yaml}
-  env:
-    config_path: /tmp/awx-molecule.yaml
 
 verifier:
   name: ansible
 
 scenario:
-  name: awx
+  name: rke
   test_sequence:
-    - destroy
     - dependency
     - syntax
-    - create
-    - prepare
-    - converge


### PR DESCRIPTION
Resolves finding #6 of #1043.

## The problem

The `molecule/` suites existed but nothing ever ran them. And if anything had, they would have tested the wrong collection.

Every scenario resolved its dependency step from the top-level `requirements.yaml`:

```yaml
dependency:
  name: galaxy
  options:
    requirements-file: requirements.yaml
    force: True
```

That file pins the **published** `sthings.*` collections. With `force: True`, molecule's dependency step would overwrite a freshly built collection with the last release — so a PR would have been gated on code that was already shipped, and the change under review would never have been executed.

## The fix

**Split the pin files.**

- `molecule/requirements.yaml` (new) — upstream collections only. This is what molecule's dependency step reads. No `sthings.*` entries, so `force: True` has nothing of ours to clobber.
- `requirements.yaml` (top level) — unchanged, stays the consumer-facing pin file.

The `sthings.*` collections are installed by the workflow **before** molecule runs, in order:

1. `ansible-galaxy collection install -r requirements.yaml` — published pins, providing the cross-collection imports a scenario needs (`molecule/container/converge.yaml` pulls in `sthings.baseos.users` as well as `sthings.container.tools`)
2. `ansible-galaxy collection install --force <built .tar.gz>` — the collection actually under test, overwriting its published counterpart

## Wiring the scenarios in, by cost

| scenario | where | why |
|---|---|---|
| `baseos` | PR gate | converges in a container, cheap |
| `container` | PR gate | same |
| `awx` | nightly (`nightly-molecule-awx.yaml`) | `prepare.yml` builds a kind cluster, deploys AWX, waits for readiness, needs vault credentials — too slow for a PR gate, and on `pull_request` it would expose those secrets the way finding #9 describes |
| `rke` | PR gate, **syntax-only** | its playbooks deploy real clusters |

`molecule/rke/` is new. Its `test_sequence` stops at `syntax` — no container is created, nothing converges. `converge.yaml` imports all seven rke playbooks purely so `--syntax-check` parses each one and resolves its includes. That is deliberately narrow, but it catches the failure mode that actually reached production: a playbook that does not parse, or a `src:`/`include:` that does not resolve in the built collection (which is how the `.yaml` template-suffix bug, finding #10, escaped).

Idempotence runs `continue-on-error: true`. These playbooks have never been held to idempotence, so it reports rather than blocks. It is skipped for `rke`, which has no instance to re-run against.

## Verification

Locally, in a scratch venv (molecule 26.6.0, molecule-docker 2.1.0):

- `molecule test -s rke` — exit 0, `syntax: Executed: Successful`
- **Clobber regression**, run twice, both clean:

```
STEP 1: published pins (requirements.yaml)
  baseos after pins:               26.2.675   <- last release
STEP 2: built artifact, --force
  baseos after build install:      26.2.440   <- build under test
STEP 3: molecule dependency -s rke
  exit code: 0
STEP 4: assert not clobbered
  baseos after molecule dependency: 26.2.440   PASS
```

Before this change, step 4 would have read `26.2.675`.

- Both workflows pass `check-jsonschema --builtin-schema vendor.github-workflows`.

## Not in scope

- The scenarios still have no `verify.yml` assertions — they prove the playbooks *run*, not that they produced the right result. Worth a follow-up.
- `rke` stays syntax-only; growing it into a real converge needs a cluster-capable runner.

## Note on the first run

Like #1047/#1048/#1049, this touches only workflow files — the `Molecule-Test` job cannot fire until a PR actually changes `collections/baseos/**` or `collections/container/**`. The first such PR is the real test of this and of the new release rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
