### PR TITLE
feat(renovate): manage collection role pins, one PR per role

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,32 @@
   "extends": [
     "config:recommended"
   ],
+  "packageRules": [
+    {
+      "description": "ONE PR PER ROLE, COVERING EVERY COLLECTION THAT PINS IT. SHARED ROLES HAD DRIFTED UP TO 4 YEARS APART BECAUSE EACH PIN WAS BUMPED SEPARATELY - GROUPING THEM MAKES THAT REGRESSION IMPOSSIBLE TO REINTRODUCE ONE FILE AT A TIME",
+      "matchFileNames": [
+        "collections/*/collection.yaml"
+      ],
+      "groupName": "ansible role {{{replace '.*/' '' depName}}}",
+      "groupSlug": "ansible-role-{{{replace '.*/' '' depName}}}",
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "roles"
+    }
+  ],
   "customManagers": [
+      {
+          "customType": "regex",
+          "description": "STUTTGART-THINGS ROLE PINS IN THE requirements: | BLOCK OF collections/*/collection.yaml. depName IS DERIVED FROM THE src: URL, SO NO # datasource= COMMENT IS NEEDED - THAT MATTERS BECAUSE THE BLOCK IS COPIED VERBATIM INTO THE BUILT COLLECTION, SO ANY COMMENT ADDED HERE WOULD SHIP IN THE ARTIFACT",
+          "fileMatch": [
+              "^collections/[^/]+/collection\\.yaml$"
+          ],
+          "matchStrings": [
+              "src: https://github\\.com/(?<depName>stuttgart-things/[^.]+)\\.git\\s+scm: git\\s+version: (?<currentValue>\\S+)"
+          ],
+          "datasourceTemplate": "git-tags",
+          "packageNameTemplate": "https://github.com/{{{depName}}}",
+          "versioningTemplate": "regex:^(?<major>\\d{4})\\.(?<minor>\\d{2})\\.(?<patch>\\d{2})(?:-(?<build>\\d+))?$"
+      },
       {
           "customType": "regex",
           "fileMatch": [


### PR DESCRIPTION
Resolves finding #5 of #1043.

## The problem

17 role pins across four `collections/*/collection.yaml` files, bumped entirely by hand. Renovate's existing custom managers all require a trailing `# datasource=…` comment and none of the pins have one, so **nothing has ever watched them**. Five have drifted:

| role | collection | pinned | latest | behind |
|---|---|---|---|---|
| `create-send-webhook` | container | `2022.01.01` | `2024.09.06` | **4.5 years** |
| `download-install-binary` | baseos | `2025.01.14` | `2026.07.15` | 18 months |
| `download-install-binary` | rke | `2025.03.27` | `2026.07.15` | 16 months |
| `install-configure-docker` | awx | `2025.04.24` | `2026.07.19` | 15 months |
| `install-configure-docker` | baseos | `2026.05.09` | `2026.07.19` | 2 months |

The other 12 are current. And nothing rebuilds a collection when an upstream role cuts a tag.

## Deriving depName from the URL, not from comments

The obvious fix — add `# datasource=git-tags depName=…` to each pin — is wrong here for two reasons:

1. The pins live inside a `requirements: |` **block scalar** that the Dagger module copies verbatim into the built collection. A comment added there ships in the artifact.
2. `renovate.json`'s pre-existing third custom manager already matches `version: X.Y.Z # datasource=…` in *any* `.yaml`. Adding the comments would have silently activated it with `github-releases` + `semver` defaults.

So the new manager matches the `src:`/`scm:`/`version:` triple and takes `depName` from the URL. **No comments needed anywhere.**

## Why versioning has to be constrained

These roles are CalVer (`YYYY.MM.DD`) and their tag namespaces are dirty. `deploy-configure-rke` alone carries 52 tags mixing CalVer, four-part versions (`1.30.4.6`), and junk (`v`, `hello`, `ls`, `containerd-importer-259`).

Under default `semver`, **`2026.06.08-2` parses as a *prerelease* of `2026.06.08`** — Renovate would have offered the rke pin `2026.06.08-2` → `2026.06.08` as an upgrade, which is a downgrade in content. Hence the explicit regex versioning, which treats the `-N` suffix as a build.

Verified against Renovate's own `RegExpVersioningApi` using the real tag lists:

```
isValid    2026.06.08-2  2026.13.04  2026.07.15  2022.01.01  ->  all true
rejected   v  hello  ls  1.30.4.6  rke2r2-1.26.0  05092023  2026-03-03
ordering   2026.06.08-2 > 2026.06.08      <- the semver trap, now correct
           2026.06.08-2 > 2026.06.08-1
           2026.07.15   > 2026.06.08-2
```

## Grouping

One PR per **role**, covering every collection that pins it. Bumping `install-configure-docker` in awx + baseos + container as a single PR is the mechanism that stops shared roles drifting apart again — per-pin PRs let the same regression back in one file at a time.

Expect three PRs once this merges:

- `ansible role install-configure-docker` — awx `2025.04.24`, baseos `2026.05.09` → `2026.07.19`
- `ansible role download-install-binary` — baseos `2025.01.14`, rke `2025.03.27` → `2026.07.15`
- `ansible role create-send-webhook` — container `2022.01.01` → `2024.09.06`

Each deserves individual review; `create-send-webhook` in particular drops 2.5 years of role change into `container`.

## This also closes the rebuild-on-role-release todo

A Renovate PR here edits `collections/**`, which is exactly `pr-collection-build.yaml`'s path filter. So the collection builds, Molecule runs against **that build** (#1052), and the release is cut on merge to main (#1047). No separate workflow needed.

It also means the first of those three PRs is the **first PR to touch `collections/**` under the new rules** — the real end-to-end test of #1047, #1048, #1049 and #1052, on a change that is trivial to revert.

## Verification

- `renovate-config-validator` — "Config validated successfully"
- Renovate's actual regex manager run against the four real files: **17 of 17 pins extracted**, all with `datasource=git-tags` and the regex versioning applied
- Confirmed the four pre-existing custom managers extract **0** deps from `collections/`, so there is no double-management

## Correction to #1043

The issue states that `manage-filesystem: 2026.13.04` in baseos is "clearly a transposed `2026.04.13`" needing a fix. **The pin is correct.** `2026.13.04` is a real upstream tag on commit `59f13f9`, which is genuinely newer than `2026.03.03` (`b400767`). Its commit date is `2026-04-13` — so the transposition happened when tagging **upstream**, not when pinning here. baseos is on the newest content. The malformed tag name is worth an issue against `stuttgart-things/manage-filesystem`, but nothing in this repo needs changing. Issue text corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
