### PR TITLE
fix(ci): pin the reusable workflow and drop the privileged PR runner

### DIFF
--- a/.github/workflows/dispatch-collection-build.yml
+++ b/.github/workflows/dispatch-collection-build.yml
@@ -27,9 +27,18 @@ on:
 # THE MANUAL RE-RELEASE PATH. SINCE RELEASES ONLY HAPPEN ON MERGE TO MAIN,
 # THIS IS HOW A COLLECTION IS REBUILT AND REPUBLISHED WITHOUT A CODE CHANGE -
 # FOR EXAMPLE AFTER A DAGGER MODULE BUMP CHANGES THE BUILT ARTIFACT
+permissions:
+  contents: read
+
 jobs:
   Build-Collection:
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@main
+    # THIS PATH CAN PUBLISH (publish-release IS AN INPUT), SO IT NEEDS THE SAME
+    # SIGNING SCOPES AS THE MERGE-TO-MAIN PATH
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@627fa26ea590c7ace7bf173a3660129367baab66 # main
     with:
       runs-on: ubuntu-latest
       environment-name: k8s

--- a/.github/workflows/main-collection-build.yaml
+++ b/.github/workflows/main-collection-build.yaml
@@ -13,10 +13,16 @@ concurrency:
   group: collection-release-${{ github.ref }}
   cancel-in-progress: false
 
+# LEAST PRIVILEGE BY DEFAULT. INDIVIDUAL JOBS WIDEN THIS WHERE THEY MUST
+permissions:
+  contents: read
+
 jobs:
   Analyze-Collection-Config:
     name: Analyze Collection Config
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       collection_folders: ${{ steps.changed-files.outputs.collection_folders }}
       has_changes: ${{ steps.changed-files.outputs.has_changes }}
@@ -74,7 +80,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.Analyze-Collection-Config.outputs.collection_folders) }}
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@main
+    # THE RELEASE PATH SIGNS A BUILD PROVENANCE ATTESTATION. A REUSABLE WORKFLOW
+    # CANNOT GRANT ITSELF MORE THAN ITS CALLER DID, SO THE SCOPES HAVE TO BE
+    # HANDED DOWN FROM HERE
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@627fa26ea590c7ace7bf173a3660129367baab66 # main
     with:
       runs-on: ubuntu-latest
       environment-name: k8s

--- a/.github/workflows/nightly-molecule-awx.yaml
+++ b/.github/workflows/nightly-molecule-awx.yaml
@@ -22,6 +22,9 @@ concurrency:
   group: nightly-molecule-awx
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   Molecule-AWX:
     name: Molecule AWX

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -9,22 +9,33 @@ on:
     paths:
       - 'collections/**'
 
+# LEAST PRIVILEGE BY DEFAULT. INDIVIDUAL JOBS WIDEN THIS WHERE THEY MUST
+permissions:
+  contents: read
+
 jobs:
   Analyze-Collection-Config:
-    container:
-      image: ghcr.io/stuttgart-things/github.com/stuttgart-things/machineshop:v2.6.13
-    environment: k8s
+    # WAS runs-on: ghr-ansible-in-cluster INSIDE THE machineshop CONTAINER, WITH
+    # environment: k8s AND A PAT. THIS JOB ONLY CURLS THE FILES API AND RUNS jq
+    # AND awk - IT NEVER NEEDED THE IN-CLUSTER RUNNER OR THOSE CREDENTIALS.
+    # EXPOSING A SELF-HOSTED RUNNER ON pull_request IS THE RISK FINDING #9
+    # DESCRIBES, AND THE SAFEST WAY TO RESTRICT IT IS NOT TO USE IT HERE
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       collection_folders: ${{ steps.changed-files.outputs.collection_folders }}
       has_changes: ${{ steps.changed-files.outputs.has_changes }}
       molecule_folders: ${{ steps.changed-files.outputs.molecule_folders }}
       has_molecule: ${{ steps.changed-files.outputs.has_molecule }}
-    runs-on: ghr-ansible-in-cluster
+    runs-on: ubuntu-latest
     steps:
       - name: Get Modified Files by PullRequest
         id: changed-files
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # THE BUILT-IN TOKEN, NOT A PAT. READING THE FILES API OF A PR IN THIS
+          # PUBLIC REPO NEEDS NOTHING MORE, AND IT EXPIRES WITH THE JOB
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eu
 
@@ -113,7 +124,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.Analyze-Collection-Config.outputs.collection_folders) }}
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@main
+    # BUILD ONLY. THE RELEASE JOB INSIDE THE REUSABLE WORKFLOW IS SKIPPED HERE
+    # (publish-release: false), SO NO SIGNING SCOPE IS HANDED TO A PR BRANCH
+    permissions:
+      contents: read
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@627fa26ea590c7ace7bf173a3660129367baab66 # main
     with:
       runs-on: ubuntu-latest
       environment-name: k8s


### PR DESCRIPTION
Companion to stuttgart-things/github-workflow-templates#125 and #126. Together these close finding #9 of #1043 apart from one item, noted at the end.

## 1. The self-hosted runner is no longer on the `pull_request` path

`Analyze-Collection-Config` ran on `ghr-ansible-in-cluster`, inside the `machineshop` container, with `environment: k8s` and a PAT — on the `pull_request` trigger.

That job curls the files API and runs `jq` and `awk`. It never needed the in-cluster runner, the container, the environment, or the PAT.

The issue's todo said "restrict the self-hosted runner to non-fork PRs". A fork guard would have been worse than it looks: skipping the job leaves `has_changes` empty, so every downstream job skips and the PR reports **success** having built nothing — the same fail-toward-green shape as #1048. So rather than guard it, this stops using it:

- `runs-on: ubuntu-latest`, no container, no `environment: k8s`
- `${{ github.token }}` instead of `secrets.GH_TOKEN` — scoped to the job and expiring with it

The repo is public, so reading a PR's file list needs nothing more. This also makes the PR path match `main-collection-build.yaml`, which already did its detection on `ubuntu-latest` with no token at all.

## 2. SHA-pinned reusable workflow references

All three `call-ansible-collection.yaml@main` references — in `pr-collection-build.yaml`, `main-collection-build.yaml` and `dispatch-collection-build.yml`, each with `secrets: inherit` — now point at `627fa26`. Every `uses:` *inside* that workflow was already SHA-pinned; the entry point was the one unpinned link.

`627fa26` is also the commit that publishes checksums and provenance, so this bump activates that work.

## 3. Explicit least-privilege permissions

No workflow declared `permissions`, so every job took the repository default. Now:

| workflow / job | scopes |
|---|---|
| all workflows (default) | `contents: read` |
| `Analyze-Collection-Config` (PR) | `+ pull-requests: read` |
| `Build-Collections` (PR) | `contents: read` — **no signing scope**; it cannot release |
| `Build-Collections` (main) | `+ id-token: write`, `attestations: write` |
| `Build-Collection` (dispatch) | `+ id-token: write`, `attestations: write` |

The last two are required because a reusable workflow cannot grant itself more than its caller did, and #125 signs an attestation. The PR path is deliberately left without them.

## What this gives consumers

Once a release runs through the new path:

```
gh attestation verify sthings-baseos-<version>.tar.gz --repo stuttgart-things/ansible
```

plus a `.sha256` asset next to the tarball.

## Verification

`check-jsonschema --builtin-schema vendor.github-workflows` passes on all four workflows. Grepped the final state: no `ghr-ansible-in-cluster`, no `machineshop`, and no `secrets.GH_TOKEN` left on the PR path.

The attestation and checksum steps themselves cannot be exercised until a real collection release runs — the first Renovate role-bump PR (#1055) will be it.

## Still open under #9

**Release notes are still not a changelog.** They now carry the digest and source commit, but what *changed* between two pins is unanswered. `--generate-notes` would need a change to the Dagger module's `GithubRelease`, which hardcodes `--notes`. Left deliberately rather than half-done.

`secrets: inherit` also remains on all three reusable calls. Narrowing it to the specific secrets needed is worth doing, but the reusable workflow's dependencies there aren't fully mapped, and guessing would break the build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY