### PR TITLE
fix(ci): grant signing scopes to the PR build caller

### DIFF
--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -124,10 +124,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.Analyze-Collection-Config.outputs.collection_folders) }}
-    # BUILD ONLY. THE RELEASE JOB INSIDE THE REUSABLE WORKFLOW IS SKIPPED HERE
-    # (publish-release: false), SO NO SIGNING SCOPE IS HANDED TO A PR BRANCH
+    # GITHUB VALIDATES A NESTED JOB'S REQUESTED PERMISSIONS EVEN WHEN THAT JOB
+    # IS SKIPPED. Release-Collection NEVER RUNS HERE (publish-release: false),
+    # BUT ITS DECLARATION IS STILL CHECKED AGAINST WHAT THIS CALLER GRANTS, SO
+    # WITHDRAWING THE SIGNING SCOPES MADE THE WHOLE WORKFLOW FILE INVALID.
+    #
+    # GRANTING THEM DOES NOT HAND THEM TO THE BUILD: collection-build DECLARES
+    # contents: read FOR ITSELF, AND A NESTED JOB ONLY EVER GETS WHAT IT ASKS
+    # FOR. THE CAP THAT MATTERS IS THERE, NOT HERE
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@627fa26ea590c7ace7bf173a3660129367baab66 # main
     with:
       runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the invalid workflow file introduced by #1056.

```
The nested job 'Release-Collection' is requesting 'attestations: write, id-token: write',
but is only allowed 'attestations: none, id-token: none'.
```

## What I got wrong

#1056 deliberately withheld `id-token: write` and `attestations: write` from the `pull_request` path, reasoning that `Release-Collection` is skipped there because `publish-release: false`.

**GitHub validates a nested job's requested permissions even when the job never runs.** The `if:` is not consulted at validation time — the declaration alone is checked against what the caller granted. So withdrawing the scopes did not restrict a skipped job, it made the entire workflow file invalid.

Impact while merged: **any PR touching `collections/**` could not start at all.** That includes the three Renovate role-bump PRs from #1055.

## The fix

Grant the scopes on `Build-Collections`. This does not hand them to the build: `collection-build` inside the reusable workflow declares `contents: read` for itself, and a nested job only ever receives what it asks for. The cap that matters lives there, not here — the caller grant is just the ceiling.

So the isolation #1056 described still holds, it is simply enforced one level down instead of at the caller.

## Verification

Schema validation passes, but that is not what failed — `check-jsonschema` cannot resolve a remote reusable workflow, so it never saw this. **This fix cannot be proven locally.** The definitive check is a PR that actually touches `collections/**`; the first Renovate role-bump PR will be it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY