### PR TITLE
docs(baseos): correct stale role versions in the readme

### DIFF
--- a/collections/baseos/README.md
+++ b/collections/baseos/README.md
@@ -5,7 +5,7 @@
 <details><summary>INSTALL COLLECTION</summary>
 
 ```bash
-COLLECTION_VERSION=25.4.1257
+COLLECTION_VERSION=26.2.675
 ansible-galaxy collection install https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-${COLLECTION_VERSION}/sthings-baseos-${COLLECTION_VERSION}.tar.gz -f
 ```
 
@@ -16,12 +16,12 @@ ansible-galaxy collection install https://github.com/stuttgart-things/ansible/re
 | Role | Version | Description |
 |------|---------|-------------|
 | download-install-binary | 2025.01.14 | Binary download and installation |
-| create-os-user | 2025.10.11 | OS user creation |
-| install-requirements | 2025.12.12 | General requirements installation |
-| manage-filesystem | 2026.03.03 | LVM filesystem management |
-| install-configure-vault | 2025.12.11 | Vault integration and CA certificates |
+| create-os-user | 2026.07.22 | OS user creation |
+| install-requirements | 2026.04.13 | General requirements installation |
+| manage-filesystem | 2026.13.04 | LVM filesystem management |
+| install-configure-vault | 2026.04.23 | Vault integration and CA certificates |
 | create-send-webhook | 2024.09.06 | Webhook creation |
-| install-configure-docker | 2025.04.24 | Docker installation |
+| install-configure-docker | 2026.05.09 | Docker installation |
 
 ## PLAYBOOKS
 


### PR DESCRIPTION
Five of the seven `ROLE DEPS` rows disagreed with what `collections/baseos/collection.yaml` actually pins, and the install example still referenced `25.4.1257`:

| role | readme said | actually pinned |
|---|---|---|
| `create-os-user` | 2025.10.11 | **2026.07.22** |
| `install-requirements` | 2025.12.12 | **2026.04.13** |
| `manage-filesystem` | 2026.03.03 | **2026.13.04** |
| `install-configure-vault` | 2025.12.11 | **2026.04.23** |
| `install-configure-docker` | 2025.04.24 | **2026.05.09** |

The table is hand-maintained, so it drifted exactly the way the pins themselves did (#1043 finding #5).

---

**This PR is also the first change to `collections/**` under the new pipeline rules**, so it is the end-to-end test of everything merged today. Expect on this PR:

- `Analyze-Collection-Config` resolving to `collections/baseos` on `ubuntu-latest` with the built-in token — no self-hosted runner (#1056)
- a build via the SHA-pinned reusable workflow, **with no release** (#1047, `publish-release: false`)
- the workflow file parsing at all, which is what #1061 fixed
- `Molecule` running `baseos` against **that build**, not the last release (#1052)

and on merge:

- one release, tagged `sthings-baseos-<version>` with no `.tar.gz` in the ref (#123)
- version `26.729.xxxx` — the monotonic scheme (#1049), jumping from `26.6.x`
- a `.sha256` asset and a verifiable provenance attestation (#125, #126)

If Molecule fails, the first suspect is #1054, which moved both Molecule workflows to Python 3.14 without anything having run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY