### PR TITLE
fix(ci): correct download-artifact version and sha-pin the actions

### DIFF
--- a/.github/workflows/main-collection-build.yaml
+++ b/.github/workflows/main-collection-build.yaml
@@ -28,7 +28,7 @@ jobs:
       has_changes: ${{ steps.changed-files.outputs.has_changes }}
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: '0'
 

--- a/.github/workflows/nightly-molecule-awx.yaml
+++ b/.github/workflows/nightly-molecule-awx.yaml
@@ -32,12 +32,12 @@ jobs:
     environment: k8s
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch-name || 'main' }}
 
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.14'
 

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -175,7 +175,7 @@ jobs:
         shell: bash
 
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.14'
 
@@ -188,7 +188,7 @@ jobs:
         shell: bash
 
       - name: Download Built Collection
-        uses: actions/download-artifact@v7.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # THE ARTIFACT IS NAMED sthings-<collection>-<version>.tar.gz AND THE
           # VERSION IS NOT KNOWN HERE, SO MATCH ON THE PREFIX


### PR DESCRIPTION
Found by #1062, the first PR to actually exercise the Molecule job.

```
##[error]Unable to resolve action `actions/download-artifact@v7.0.1`, unable to find version `v7.0.1`
```

`v7.0.1` is **upload-artifact's** latest. `download-artifact` is at **v8.0.1**. #1052 carried the wrong one across, and the job failed before running a single step.

Nothing caught it: `check-jsonschema` validates workflow *structure* and never resolves an action reference, and the job only runs on a PR touching `collections/**` — which had not happened until now. Verified the other two are real (`checkout@v7.0.1` ✓, `setup-python@v6.3.0` ✓), so this was the only bad ref.

## Also SHA-pinning

Finding #9's first todo was to SHA-pin the reusable workflow reference, which #1056 did. But the plain actions in the same repo were left on floating tags, in a repo where every other `uses:` is now pinned. Fixed while here:

| action | pin | was |
|---|---|---|
| `actions/checkout` | `3d3c42e` | `@v7.0.1` |
| `actions/setup-python` | `ece7cb0` | `@v6.3.0` |
| `actions/download-artifact` | `3e5f45b` | `@v7.0.1` ❌ |

Version comments are retained so Renovate keeps updating them.

## What #1062 did prove

The rest of the pipeline behaved exactly as designed on that run:

| job | result | |
|---|---|---|
| `Analyze-Collection-Config` | ✅ | resolved `collections/baseos` on `ubuntu-latest`, built-in token, no self-hosted runner (#1056) |
| `Collection Build` | ✅ | built via the SHA-pinned reusable workflow |
| `Release-Collection` | ⏭️ skipped | correct — PRs do not publish (#1047) |
| `Molecule` | ❌ | this bug |

The workflow file parsing at all also confirms #1061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY