### PR TITLE
fix(molecule): replace molecule-docker with molecule-plugins

### DIFF
--- a/.github/workflows/nightly-molecule-awx.yaml
+++ b/.github/workflows/nightly-molecule-awx.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           set -eu
           pip install --upgrade pip setuptools
-          pip install 'molecule' 'molecule-docker' netaddr
+          pip install 'molecule' 'molecule-plugins[docker]' netaddr
           molecule --version
         shell: bash
 

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -183,7 +183,7 @@ jobs:
         run: |
           set -eu
           pip install --upgrade pip setuptools
-          pip install 'molecule' 'molecule-docker' netaddr
+          pip install 'molecule' 'molecule-plugins[docker]' netaddr
           molecule --version
         shell: bash
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -118,7 +118,7 @@ tasks:
     preconditions: *venv
     cmds:
       - pip install -U setuptools pip 'molecule'
-      - pip install molecule-docker
+      - pip install 'molecule-plugins[docker]'
       - pip install netaddr
       - molecule --version
       - ansible-galaxy collection install community.docker

--- a/molecule/baseos/molecule.yml
+++ b/molecule/baseos/molecule.yml
@@ -13,8 +13,9 @@ driver:
 platforms:
   - name: ubuntu24
     image: geerlingguy/docker-ubuntu2404-ansible@sha256:129f93fb11c00d2452f541fc926234a2ecf7957d7348fb07832bd0bf6973f503
-    command:
-      - ${MOLECULE_DOCKER_COMMAND:-""}
+    # A STRING, NOT A LIST. THE molecule-plugins DOCKER DRIVER SCHEMA REJECTS
+    # THE LIST FORM molecule-docker ACCEPTED, AND container/awx ALREADY USE THIS
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host


### PR DESCRIPTION
Found by #1062, the first PR to actually run the Molecule job.

## The failure

```
molecule_docker/playbooks/destroy.yml
  when: (lookup('env', 'HOME'))     <- a string, not a boolean
Broken conditionals can be temporarily allowed with `ALLOW_BROKEN_CONDITIONALS`
```

ansible-core 2.19 made non-boolean conditionals a hard error. `molecule-docker` still ships one, so the driver dies at the **first** `destroy` step — nothing downstream ever runs.

`molecule-docker` is abandoned at 2.1.0 (last release; no fix coming). `molecule-plugins` is maintained — 26.7.15, two weeks old — and provides the same `docker` driver name, so `molecule.yml` keeps `driver: name: docker`.

## Not a drop-in swap

The `molecule-plugins` schema requires platform `command:` to be a **string** and rejects the list form `molecule-docker` accepted:

```
Failed to validate molecule/baseos/molecule.yml
["['/lib/systemd/systemd'] is not of type 'string'"]
```

`baseos` was the only scenario on the list form; `container` and `awx` already used a string, `rke` has no `command:`. Now consistent.

`Taskfile.yaml:121` installed `molecule-docker` as well — left alone, `task setup-molecule` would keep using the broken driver locally while CI used the new one.

## Correcting two things I said earlier

1. **This was never a Python 3.14 problem.** I named #1054 as the prime suspect twice. The failing run installed `ansible-core 2.21.2`, which reproduces this identically on 3.12. #1054 is exonerated.
2. **#1052's verification had a real hole.** I validated it with `molecule test -s rke` — syntax-only, which never touches the docker driver — and never ran a converging scenario locally. The entire docker path went untested while I reported the suite as working. Both bugs found since (#1063's bad action ref, and this) were in that blind spot.

## Verification

A real converge, locally, against the **built** artifact rather than the published one:

```
SCENARIO RECAP
baseos : actions=6  successful=4  disabled=0  skipped=0  missing=2  failed=0

baseos ➜ destroy    : Executed: Successful
baseos ➜ dependency : Missing roles requirements file: requirements.yml   (warning)
baseos ➜ syntax     : Executed: Successful
baseos ➜ create     : Executed: Successful
baseos ➜ prepare    : Missing playbook                                     (warning)
baseos ➜ converge   : Executed: Successful

PLAY RECAP  ubuntu24 : ok=272  changed=65  unreachable=0  failed=0

sthings.baseos  26.2.440    <- the build under test, not the published 26.2.675
```

The two `missing` entries are informational — no roles `requirements.yml`, and `baseos` has no `prepare.yml`. Neither is a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY