### PR TITLE
fix(renovate): manage the dagger module and cli pins

### DIFF
--- a/.github/workflows/dispatch-collection-build.yml
+++ b/.github/workflows/dispatch-collection-build.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@627fa26ea590c7ace7bf173a3660129367baab66 # main
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@80a37e2b85ef8a3ed714d8e9c5f96625393c92ba # main
     with:
       runs-on: ubuntu-latest
       environment-name: k8s

--- a/.github/workflows/main-collection-build.yaml
+++ b/.github/workflows/main-collection-build.yaml
@@ -87,7 +87,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@627fa26ea590c7ace7bf173a3660129367baab66 # main
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@80a37e2b85ef8a3ed714d8e9c5f96625393c92ba # main
     with:
       runs-on: ubuntu-latest
       environment-name: k8s

--- a/.github/workflows/pr-collection-build.yaml
+++ b/.github/workflows/pr-collection-build.yaml
@@ -136,7 +136,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@627fa26ea590c7ace7bf173a3660129367baab66 # main
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-collection.yaml@80a37e2b85ef8a3ed714d8e9c5f96625393c92ba # main
     with:
       runs-on: ubuntu-latest
       environment-name: k8s

--- a/renovate.json
+++ b/renovate.json
@@ -16,68 +16,100 @@
     }
   ],
   "customManagers": [
-      {
-          "customType": "regex",
-          "description": "STUTTGART-THINGS ROLE PINS IN THE requirements: | BLOCK OF collections/*/collection.yaml. depName IS DERIVED FROM THE src: URL, SO NO # datasource= COMMENT IS NEEDED - THAT MATTERS BECAUSE THE BLOCK IS COPIED VERBATIM INTO THE BUILT COLLECTION, SO ANY COMMENT ADDED HERE WOULD SHIP IN THE ARTIFACT",
-          "fileMatch": [
-              "^collections/[^/]+/collection\\.yaml$"
-          ],
-          "matchStrings": [
-              "src: https://github\\.com/(?<depName>stuttgart-things/[^.]+)\\.git\\s+scm: git\\s+version: (?<currentValue>\\S+)"
-          ],
-          "datasourceTemplate": "git-tags",
-          "packageNameTemplate": "https://github.com/{{{depName}}}",
-          "versioningTemplate": "regex:^(?<major>\\d{4})\\.(?<minor>\\d{2})\\.(?<patch>\\d{2})(?:-(?<build>\\d+))?$"
-      },
-      {
-          "customType": "regex",
-          "fileMatch": [
-              "\\.yaml$"
-          ],
-          "matchStrings": [
-              "\\s*(?<binName>.+)_version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
-          ],
-          "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
-          "extractVersionTemplate": "^v?(?<version>.*)$",
-          "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
-          "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
-      },
-      {
-        "customType": "regex",
-        "fileMatch": [
-            "\\.yaml$"
-        ],
-        "matchStrings": [
-            "\\s*(?<binName>.+)Version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
-        ],
-        "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
-        "extractVersionTemplate": "^v?(?<version>.*)$",
-        "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
-        "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
-      },
-      {
-        "customType": "regex",
-        "fileMatch": [
-            "\\.yaml$"
-        ],
-        "matchStrings": [
-            "\\s*version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
-        ],
-        "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
-        "extractVersionTemplate": "^v?(?<version>.*)$",
-        "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
-        "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
-      },
-      {
-          "customType": "regex",
-          "fileMatch": ["^Dockerfile$"],
-          "matchStrings": [
-              "\\s*(?<binName>.+)_version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
-          ],
-          "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
-          "extractVersionTemplate": "^v?(?<version>.*)$",
-          "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
-          "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
+    {
+      "customType": "regex",
+      "description": "STUTTGART-THINGS ROLE PINS IN THE requirements: | BLOCK OF collections/*/collection.yaml. depName IS DERIVED FROM THE src: URL, SO NO # datasource= COMMENT IS NEEDED - THAT MATTERS BECAUSE THE BLOCK IS COPIED VERBATIM INTO THE BUILT COLLECTION, SO ANY COMMENT ADDED HERE WOULD SHIP IN THE ARTIFACT",
+      "fileMatch": [
+        "^collections/[^/]+/collection\\.yaml$"
+      ],
+      "matchStrings": [
+        "src: https://github\\.com/(?<depName>stuttgart-things/[^.]+)\\.git\\s+scm: git\\s+version: (?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "git-tags",
+      "packageNameTemplate": "https://github.com/{{{depName}}}",
+      "versioningTemplate": "regex:^(?<major>\\d{4})\\.(?<minor>\\d{2})\\.(?<patch>\\d{2})(?:-(?<build>\\d+))?$"
+    },
+    {
+      "customType": "regex",
+      "description": "STUTTGART-THINGS DAGGER ANSIBLE MODULE PIN. LIVES IN SIX PLACES ACROSS TWO REPOS AND WAS ALIGNED BY HAND THREE TIMES",
+      "fileMatch": [
+        "^Taskfile\\.yaml$",
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "DAGGER_ANSIBLE_MODULE_VERSION:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "dagger-module-version:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "dagger-module-version:\\n(?:[ \\t]+[^\\n]*\\n)*?[ \\t]+default:[ \\t]*['\"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)['\"]?"
+      ],
+      "depNameTemplate": "stuttgart-things/dagger",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "DAGGER CLI PIN, PASSED TO dagger/dagger-for-github",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "dagger-version:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "dagger-version:\\n(?:[ \\t]+[^\\n]*\\n)*?[ \\t]+default:[ \\t]*['\"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)['\"]?"
+      ],
+      "depNameTemplate": "dagger/dagger",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s*(?<binName>.+)_version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s*(?<binName>.+)Version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s*version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^Dockerfile$"
+      ],
+      "matchStrings": [
+        "\\s*(?<binName>.+)_version:\\s(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*#\\s*(datasource=(?<datasource>[^\\s]*))\\s*(depName=(?<depName>[^\\s]*))?\\s*"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "depNameTemplate": "{{#if depName}}{{{depName}}}{{else}}{{{binName}}}{{/if}}"
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
Closes the remaining half of finding #8 of #1043. Companion to stuttgart-things/github-workflow-templates#128.

## State of #8

The part that made it a finding — local and CI calling **different Dagger entrypoints** — was fixed in #1045. Both now call `run-collection-build-pipeline`.

What stayed open was the todo: *"add a Renovate rule so all three bump together"*. It is actually **six** places across two repos:

| repo | file |
|---|---|
| ansible | `Taskfile.yaml` |
| ansible | `pr-collection-build.yaml` |
| ansible | `main-collection-build.yaml` |
| ansible | `dispatch-collection-build.yml` |
| templates | `call-ansible-collection.yaml` |
| templates | `call-release-artifact.yaml` |

All six currently read `v0.121.0` / `v0.21.7`, matching upstream — but only because they were aligned **by hand three times this week**. Nothing watches them, so they drift by default. That is precisely the #5 pattern, and #5 turned out to be five stale pins out of seventeen.

## One had already drifted

`call-release-artifact.yaml` defaulted to `dagger-module-version: v0.2.1` — about **119 releases** behind — and `dagger-version: "0.18.10"`. Same trap templates#121 fixed at `v0.13.0`, and masked the same way: every caller passes explicit values.

Called *without* them it would silently run a module predating the monotonic version scheme and the tag rename, publishing a release tagged with a filename at a version that can run backwards. Fixed in templates#128.

## Why new managers were needed

The existing custom managers key on `_version:` and `Version:`. Neither matches `dagger-module-version:`, and `DAGGER_ANSIBLE_MODULE_VERSION:` is uppercase so it matches nothing at all. One of the six is a `workflow_call` input default where the key and value are three lines apart, needing a multi-line match.

## Verification

Renovate's own regex extractor over the real files:

```
Taskfile.yaml                     stuttgart-things/dagger  v0.121.0
pr-collection-build.yaml          stuttgart-things/dagger  v0.121.0
                                  dagger/dagger            v0.21.7
main-collection-build.yaml        stuttgart-things/dagger  v0.121.0
                                  dagger/dagger            v0.21.7
dispatch-collection-build.yml     stuttgart-things/dagger  v0.121.0
                                  dagger/dagger            v0.21.7
```

**7 of 7** in this repo, **11 of 11** across both. The role-pin manager from #1055 still returns its 7 deps for `baseos` — no interference between the two. `renovate-config-validator` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY