### PR TITLE
fix(renovate): stop splitting role updates per calendar year

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,16 @@
   ],
   "packageRules": [
     {
-      "description": "ONE PR PER ROLE, COVERING EVERY COLLECTION THAT PINS IT. SHARED ROLES HAD DRIFTED UP TO 4 YEARS APART BECAUSE EACH PIN WAS BUMPED SEPARATELY - GROUPING THEM MAKES THAT REGRESSION IMPOSSIBLE TO REINTRODUCE ONE FILE AT A TIME",
+      "description": "ONE PR PER ROLE, COVERING EVERY COLLECTION THAT PINS IT. SHARED ROLES HAD DRIFTED UP TO 4 YEARS APART BECAUSE EACH PIN WAS BUMPED SEPARATELY - GROUPING THEM MAKES THAT REGRESSION IMPOSSIBLE TO REINTRODUCE ONE FILE AT A TIME. separateMajorMinor IS OFF BECAUSE THESE ROLES ARE CALVER: THE 'MAJOR' IS THE YEAR, SO LEAVING IT ON SPLIT ONE ROLE INTO A PER-YEAR PR AND OFFERED POINTLESS INTERMEDIATE HOPS LIKE 2025.01.14 -> 2025.03.27 ALONGSIDE 2025.01.14 -> 2026.07.15",
       "matchFileNames": [
         "collections/*/collection.yaml"
       ],
       "groupName": "ansible role {{{replace '.*/' '' depName}}}",
       "groupSlug": "ansible-role-{{{replace '.*/' '' depName}}}",
       "semanticCommitType": "fix",
-      "semanticCommitScope": "roles"
+      "semanticCommitScope": "roles",
+      "separateMajorMinor": false,
+      "separateMinorPatch": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Fixes the grouping behaviour #1055 claimed but did not deliver.

## What I said vs what happened

#1055 said *"one PR per role, covering every collection that pins it."* Renovate opened four:

| PR | role | files |
|---|---|---|
| #1057 | `install-configure-docker` → 2026.07.19 | `baseos` only |
| #1067 | `install-configure-docker` → v2026 | `awx` only |
| #1058 | `download-install-binary` → 2025.03.27 | `baseos` only |
| #1066 | `download-install-binary` → v2026 | `baseos` + `rke` ✅ |

## The grouping works — `separateMajorMinor` cuts across it

#1066 spanning two collections proves the `groupName` rule is doing its job. The problem is `separateMajorMinor`, on by default.

These roles are **CalVer**, so the "major" is the year. `awx` sat on `2025.04.24` and `baseos` on `2026.05.09` — different major streams, therefore different PRs. That is precisely the per-file drift the grouping was meant to make impossible.

It also produced #1058: a bump from `2025.01.14` → `2025.03.27`, offered alongside `2026.07.15` for the same pin. An intermediate hop to a version nobody wants, because Renovate keeps a "stay on your current major" branch open.

A year boundary is not a breaking change, so the premise of major-splitting does not apply. Turned off, along with `separateMinorPatch`, so each role gets exactly one PR to the newest tag.

## What I should have caught in #1055

I verified extraction with Renovate's own extractor — 17 of 17 pins — and then asserted the grouping behaviour without testing it, because Renovate had not run yet. Extraction and update *shaping* are separate things, and I only checked the first.

Same gap as the Molecule work: verify the part that is locally testable, assert the rest. Both times the untested half was where the bug was.

## Verification

Extraction unchanged — 17 of 17 role pins still found (awx 1, baseos 7, container 5, rke 4). `renovate-config-validator` passes.

Grouping itself can only be confirmed once Renovate reruns, so this one is genuinely not proven until the next scan — stated plainly rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY