### PR TITLE
fix(ci): stop dropping collection releases on merge bursts

### DIFF
--- a/.github/workflows/main-collection-build.yaml
+++ b/.github/workflows/main-collection-build.yaml
@@ -7,11 +7,36 @@ on:
     paths:
       - 'collections/**'
 
-# NEVER CANCEL AN IN-FLIGHT RELEASE - A CANCELLED JOB CAN LEAVE A TAG
-# WITHOUT ITS ASSET. QUEUE INSTEAD SO MERGES RELEASE IN ORDER
-concurrency:
-  group: collection-release-${{ github.ref }}
-  cancel-in-progress: false
+# NO CONCURRENCY GROUP, DELIBERATELY.
+#
+# THIS USED TO CARRY:
+#   concurrency:
+#     group: collection-release-${{ github.ref }}
+#     cancel-in-progress: false
+#
+# THE INTENT WAS "NEVER CANCEL AN IN-FLIGHT RELEASE, QUEUE INSTEAD". THE EFFECT
+# WAS THE OPPOSITE. cancel-in-progress: false ONLY PROTECTS A *RUNNING* JOB -
+# GITHUB KEEPS AT MOST ONE *PENDING* RUN PER GROUP, SO EACH NEW PUSH CANCELLED
+# THE ONE STILL WAITING. OBSERVED ON A MERGE BURST:
+#
+#   9dc9d4b  success    -> sthings-baseos-26.729.1157
+#   7450423  cancelled
+#   9453030  cancelled
+#   e40f90d  success    -> sthings-container-26.729.1161
+#
+# DETECTION IS A PER-PUSH DIFF, SO A CANCELLED RUN TAKES ITS COLLECTIONS WITH
+# IT. IF A CANCELLED RUN WAS THE ONLY ONE WHOSE DIFF COVERED COLLECTION X, X
+# NEVER RELEASES - AND NOTHING SAYS SO, BECAUSE A CANCELLED RUN READS AS
+# DELIBERATE RATHER THAN FAILED.
+#
+# WITHOUT THE GROUP NO RUN IS EVER CANCELLED FOR CONCURRENCY, SO EVERY PUSH
+# RELEASES WHAT IT CHANGED. TWO RUNS CANNOT COLLIDE ON A TAG EITHER: THE
+# VERSION CARRIES THE COMMIT COUNT, SO DIFFERENT COMMITS PRODUCE DIFFERENT
+# TAGS, AND THE RELEASE JOB STILL REFUSES TO REPUBLISH AN EXISTING ONE.
+#
+# THE COST IS THAT A BURST TOUCHING ONE COLLECTION REPEATEDLY NOW PRODUCES ONE
+# RELEASE PER COMMIT INSTEAD OF ONE FOR THE LAST. THAT IS THE RIGHT TRADE:
+# EXTRA RELEASES ARE VISIBLE, DROPPED ONES ARE NOT.
 
 # LEAST PRIVILEGE BY DEFAULT. INDIVIDUAL JOBS WIDEN THIS WHERE THEY MUST
 permissions:
@@ -59,6 +84,23 @@ jobs:
           echo "CHANGED COLLECTIONS: ${CHANGED_FOLDERS:-<none>}"
 
           if [ -z "${CHANGED_FOLDERS}" ]; then
+            # THE paths FILTER ALREADY MATCHED collections/**, SO REACHING HERE
+            # MEANS EVERY CHANGED PATH WAS FILTERED OUT - collections/README.md
+            # AND THE LIKE. SAY SO LOUDLY. A RELEASE PIPELINE THAT DOES NOTHING
+            # AND REPORTS SUCCESS IS HOW #1048 AND #11 BOTH STAYED HIDDEN
+            {
+              echo "### No collection released"
+              echo ""
+              echo "The push matched \`collections/**\` but no path resolved to"
+              echo "a buildable collection, so **nothing was released**."
+              echo ""
+              echo "Changed paths in \`${BEFORE}..${{ github.sha }}\`:"
+              echo '```'
+              git diff --name-only "${BEFORE}" "${{ github.sha }}" -- collections
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            echo "NO BUILDABLE COLLECTION RESOLVED - NOTHING WILL BE RELEASED"
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "collection_folders={\"collection-directory\":[]}" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
Fixes finding #11 of #1043.

## The concurrency group did the opposite of its comment

```yaml
# NEVER CANCEL AN IN-FLIGHT RELEASE - A CANCELLED JOB CAN LEAVE A TAG
# WITHOUT ITS ASSET. QUEUE INSTEAD SO MERGES RELEASE IN ORDER
concurrency:
  group: collection-release-${{ github.ref }}
  cancel-in-progress: false
```

`cancel-in-progress: false` protects a **running** job. But GitHub keeps at most one **pending** run per group, so every new push cancelled the one still waiting. Observed on the Renovate merge burst:

```
9dc9d4b  success    -> sthings-baseos-26.729.1157
7450423  cancelled
9453030  cancelled
e40f90d  success    -> sthings-container-26.729.1161
```

Four collection-touching merges, two releases.

**Nothing was lost that time** — each build checks out the whole tree, so the surviving container release already contained the cancelled commits' changes. The mechanism is what is broken, not that outcome. Detection is a per-push diff, so a cancelled run takes its collections with it: if a cancelled run was the only one whose diff covered collection X, **X never releases**. And a cancelled run reads as deliberate, not failed, so nobody looks.

## The fix

Drop the group. No run is then cancelled for concurrency, and every push releases what it changed.

Tag collisions are not a concern: the version carries the commit count, so different commits produce different tags, and `Refuse To Republish An Existing Tag` still guards the rest.

**The trade, stated plainly:** a burst touching one collection repeatedly now produces one release per commit instead of one for the last. That is the right direction — extra releases are visible, dropped ones are not. If the volume becomes annoying the answer is diffing against each collection's last release tag rather than `github.event.before`, but that depends on the tag pointing at the built commit, and `gh release create` tags the branch head at call time, not `GITHUB_SHA`. Not worth the subtlety today.

## Plus: say something when doing nothing

If a push matches `collections/**` but no path resolves to a buildable collection, the job now writes a step summary naming the changed paths, instead of silently reporting success.

Reporting success while doing nothing is how both #1048 and this stayed hidden. Third instance of the same shape in this audit, so it is worth building the habit in.

## Ordering note

This is deliberately merged **before** the outstanding role-bump PRs (#1057, #1065, #1066). Merging those three in quick succession is precisely the burst that triggers this bug — doing it first would have reproduced the defect rather than avoided it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY