### PR TITLE
fix(baseos): apply the DNS search-domain block on every Ubuntu, not just 25.04

### DIFF
--- a/collections/baseos/setup.yaml
+++ b/collections/baseos/setup.yaml
@@ -292,7 +292,18 @@ playbooks:
                 when: domain | length > 0
             when: ansible_facts['distribution'] == "Fedora"
 
-          - name: Fix DNS resolution on Ubuntu 25.04
+          # Sets the search domain (and the matching /etc/hosts + hostnamectl
+          # FQDN) from the lab the host's IP falls into. Deliberately NOT pinned
+          # to one Ubuntu release: it was gated on 25.04 and therefore silently
+          # skipped on 26.04, which is what the whole fleet now builds. The block
+          # is a no-op unless an ip_prefix in lab_dns_map matches, so widening it
+          # cannot touch hosts outside a known lab.
+          #
+          # It matters where DHCP does not hand out a domain: LabUL VLAN 102
+          # (proxmox) does, VLAN 103 (vsphere) does not, so guests there came up
+          # with `search .` and `hostname -f` failing even though the A record
+          # resolved. Do not narrow this back to a version.
+          - name: Fix DNS resolution (search domain + FQDN) on Ubuntu
             block:
               - name: Detect lab environment from IP address
                 ansible.builtin.set_fact:
@@ -353,9 +364,7 @@ playbooks:
                 ansible.builtin.debug:
                   msg: "WARNING: Could not detect lab for IP {{ ansible_default_ipv4.address }}. DNS not configured. Add the IP prefix to lab_dns_map."
                 when: detected_lab | trim | length == 0
-            when:
-              - ansible_facts['distribution'] == "Ubuntu"
-              - ansible_facts['distribution_version'] == "25.04"
+            when: ansible_facts['distribution'] == "Ubuntu"
 
   - name: users
     play: |


### PR DESCRIPTION
The block that sets the search domain, the `/etc/hosts` FQDN line and `hostnamectl` **already existed** and already knew every LabUL prefix. It was gated on:

```yaml
when:
  - ansible_facts['distribution'] == "Ubuntu"
  - ansible_facts['distribution_version'] == "25.04"
```

The fleet builds **26.04**, so it has been silently skipped on every recent VM. The task was even named "Fix DNS resolution on Ubuntu 25.04".

## Measured

Two fresh LabUL vSphere guests (10.31.103.30/.31), after a full `sthings.baseos.setup` run reporting `ok=141 failed=0`:

```console
$ hostname
vs-1
$ grep ^search /etc/resolv.conf
search .
$ grep 127.0.1.1 /etc/hosts
127.0.1.1 localhost
$ hostname -f
hostname: Temporary failure in name resolution
$ getent hosts vs-1.labul.sva.de
10.31.103.30
```

DNS registration works and the A record is there. Only the client-side search domain is missing — precisely what this block fixes.

## Why it went unnoticed

LabUL **VLAN 102** (proxmox) DHCP hands out a domain; **VLAN 103** (vsphere) does not. Guests on 102 looked fine and hid the gap, so the two providers appeared to behave differently when in fact only one of them was being rescued by DHCP.

## The change

The gate is now Ubuntu-only, deliberately **without** a version. The block is a no-op unless an `ip_prefix` in `lab_dns_map` matches the host, so widening it cannot touch hosts outside a known lab — whereas pinning a version means every new Ubuntu release re-breaks it silently, which is what happened here.

## Tested

`collections/baseos/setup.yaml` parses (outer document and the inner `play` block scalar); the block's `when` is now the single Ubuntu condition and no `25.04` remains. Runtime verification needs a released collection — happy to re-run the two-VM batch against it once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSaY8SQK6q9nFWj4rAvZWc