### PR TITLE
chore(collections): install-requirements 2026.04.13 -> 2026.07.29

### DIFF
--- a/collections/baseos/collection.yaml
+++ b/collections/baseos/collection.yaml
@@ -24,7 +24,7 @@ requirements: |
       version: 2026.07.22
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
-      version: 2026.04.13
+      version: 2026.07.29
     - src: https://github.com/stuttgart-things/manage-filesystem.git
       scm: git
       version: 2026.13.04

--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -21,7 +21,7 @@ requirements: |
       version: 2026.07.19
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
-      version: 2026.04.13
+      version: 2026.07.29
     - src: https://github.com/stuttgart-things/install-configure-vault.git
       scm: git
       version: 2026.04.23

--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -25,7 +25,7 @@ requirements: |
       version: 2025.12.13
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
-      version: 2026.04.13
+      version: 2026.07.29
     - src: https://github.com/stuttgart-things/download-install-binary.git
       scm: git
       version: 2026.07.15


### PR DESCRIPTION
Picks up [stuttgart-things/install-requirements#44](https://github.com/stuttgart-things/install-requirements/pull/44) (released as `2026.07.29`).

## What it fixes

`Install required repo` now skips when `required_repo` is empty, instead of calling `package: name: ""` and failing on every Debian/Ubuntu host:

```
TASK [sthings.baseos.install_requirements : Install required repo for Ubuntu 26.04]
fatal: [default]: FAILED! => {"changed": false, "msg": "No package matching '' is available"}
```

`ignore_errors: true` was swallowing it, so nothing broke — it just printed a red `fatal:` on every run, **five times** in the last LabUL ubuntu26 Packer build (`ok=62 failed=0 ignored=5`). An expected `fatal:` on every host is its own cost: it trains people to skim past the ones that matter.

## Scope

Bumped in **all three** collections that pin the role, not only baseos — `rke` and `container` carry the same task and the same noise.

| collection | install-requirements |
|---|---|
| baseos | 2026.04.13 → **2026.07.29** |
| rke | 2026.04.13 → **2026.07.29** |
| container | 2026.04.13 → **2026.07.29** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSaY8SQK6q9nFWj4rAvZWc