### PR TITLE
chore: bump install-requirements to 2026.07.30 in baseos, container and rke

### DIFF
--- a/collections/baseos/collection.yaml
+++ b/collections/baseos/collection.yaml
@@ -24,7 +24,7 @@ requirements: |
       version: 2026.07.22
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
-      version: 2026.07.29
+      version: 2026.07.30
     - src: https://github.com/stuttgart-things/manage-filesystem.git
       scm: git
       version: 2026.13.04

--- a/collections/container/collection.yaml
+++ b/collections/container/collection.yaml
@@ -21,7 +21,7 @@ requirements: |
       version: 2026.07.19
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
-      version: 2026.07.29
+      version: 2026.07.30
     - src: https://github.com/stuttgart-things/install-configure-vault.git
       scm: git
       version: 2026.04.23

--- a/collections/rke/collection.yaml
+++ b/collections/rke/collection.yaml
@@ -25,7 +25,7 @@ requirements: |
       version: 2025.12.13
     - src: https://github.com/stuttgart-things/install-requirements.git
       scm: git
-      version: 2026.07.29
+      version: 2026.07.30
     - src: https://github.com/stuttgart-things/download-install-binary.git
       scm: git
       version: 2026.07.15


### PR DESCRIPTION
Picks up the corrected `required_repo` guard from install-requirements#45.

The `2026.07.29` pin these collections carry contains the **broken** guard from install-requirements#50, which trades one red `fatal:` for another on every Debian/Ubuntu host:

```
The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()
```

`ignore_errors` swallows it, so the run still "passes" and it shows up only as a nonzero `ignored` in the recap. Both template builds today shipped with it — `ubuntu24-base-20260730-0715` (`ignored=3`) and `ubuntu26-base-20260730-0742` (`ignored=5`).

Root cause: under **jinja2_native** (ansible-core default) an if/elif chain with no branch taken renders to `None`, not `''`, and `default('')` substitutes only for *undefined*. The fix is `default('', true)`.

All three collections vendor the role, so all three are bumped — pinning only baseos would leave container and rke emitting the same fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSaY8SQK6q9nFWj4rAvZWc