### PR TITLE
fix(baseos): probe vault instances in the remaining plays

### DIFF
--- a/collections/baseos/k3s-arm.yaml
+++ b/collections/baseos/k3s-arm.yaml
@@ -168,16 +168,46 @@ playbooks:
                 when: growpart_result.changed
             when: expand_rootfs|bool
 
+          # vault_instances is an infra-wide list, but any single entry can be
+          # sealed, down or behind a broken ingress at any time. Installing the CA
+          # straight from the list made ONE such instance fail the whole build. So
+          # probe first and only install from the instances that serve the CA.
+          - name: Probe vault instances for a reachable PKI CA endpoint
+            ansible.builtin.uri:
+              url: "{{ vault_instance }}/v1/pki/ca/pem"
+              method: GET
+              validate_certs: false
+              timeout: 10
+            loop: "{{ vault_instances }}"
+            loop_control:
+              loop_var: vault_instance
+            register: vault_ca_probe
+            failed_when: false
+            changed_when: false
+            when: vault_instances is defined
+
+          - name: Report unreachable vault instances
+            ansible.builtin.debug:
+              msg: >-
+                Skipping vault CA install from {{ item.vault_instance }} -
+                not reachable ({{ item.msg | default('status ' ~ (item.status | default('unknown'))) }})
+            loop: "{{ vault_ca_probe.results | default([]) | rejectattr('status', 'defined') | list
+                      + vault_ca_probe.results | default([]) | selectattr('status', 'defined') | rejectattr('status', 'equalto', 200) | list }}"
+            loop_control:
+              label: "{{ item.vault_instance }}"
+
           - name: Install vault ca certificate to local system from multiple instances
             ansible.builtin.include_role:
               name: sthings.baseos.install_configure_vault
               tasks_from: install-ca-auth
             vars:
               vault_url: "{{ vault_instance }}"
-            loop: "{{ vault_instances }}"
+            loop: "{{ vault_ca_probe.results | default([])
+                      | selectattr('status', 'defined')
+                      | selectattr('status', 'equalto', 200)
+                      | map(attribute='vault_instance') | list }}"
             loop_control:
               loop_var: vault_instance
-            when: vault_instances is defined
 
           - name: Install kubectl
             block:

--- a/plays/base-os.yaml
+++ b/plays/base-os.yaml
@@ -52,16 +52,46 @@
       when: reboot_all|bool
 
   tasks:
+    # vault_instances is an infra-wide list, but any single entry can be
+    # sealed, down or behind a broken ingress at any time. Installing the CA
+    # straight from the list made ONE such instance fail the whole build. So
+    # probe first and only install from the instances that serve the CA.
+    - name: Probe vault instances for a reachable PKI CA endpoint
+      ansible.builtin.uri:
+        url: "{{ vault_instance }}/v1/pki/ca/pem"
+        method: GET
+        validate_certs: false
+        timeout: 10
+      loop: "{{ vault_instances }}"
+      loop_control:
+        loop_var: vault_instance
+      register: vault_ca_probe
+      failed_when: false
+      changed_when: false
+      when: vault_instances is defined
+
+    - name: Report unreachable vault instances
+      ansible.builtin.debug:
+        msg: >-
+          Skipping vault CA install from {{ item.vault_instance }} -
+          not reachable ({{ item.msg | default('status ' ~ (item.status | default('unknown'))) }})
+      loop: "{{ vault_ca_probe.results | default([]) | rejectattr('status', 'defined') | list
+                + vault_ca_probe.results | default([]) | selectattr('status', 'defined') | rejectattr('status', 'equalto', 200) | list }}"
+      loop_control:
+        label: "{{ item.vault_instance }}"
+
     - name: Install vault ca certificate to local system from multiple instances
       ansible.builtin.include_role:
         name: install_configure_vault
         tasks_from: install-ca-auth
       vars:
         vault_url: "{{ vault_instance }}"
-      loop: "{{ vault_instances }}"
+      loop: "{{ vault_ca_probe.results | default([])
+                | selectattr('status', 'defined')
+                | selectattr('status', 'equalto', 200)
+                | map(attribute='vault_instance') | list }}"
       loop_control:
         loop_var: vault_instance
-      when: vault_instances is defined
 
     - name: Send event to homerun if enabled
       block:


### PR DESCRIPTION
#1005 made the Vault CA install probe-first in `collections/baseos/setup.yaml`. Two copies of the same loop were left behind and still walk `vault_instances` unguarded, so a single sealed or unroutable instance fails the whole run:

* `plays/base-os.yaml`
* `collections/baseos/k3s-arm.yaml`

A **third** copy lives in the packer plays over in stuttgart-things, and that one is what took the ubuntu26 LabUL image build down today — 26 minutes in, VM built, 52 tasks green, then:

```
TASK [sthings.baseos.install_configure_vault : Download vault CA certificate]
fatal: ... <urlopen error [Errno 113] No route to host>
```

Fixed there in stuttgart-things#2467 and verified against a real build. These two are the same defect; neither is on a hot path right now, which is exactly why they would be found the same way — by an outage, mid-build.

Same shape as `setup.yaml`: probe each instance's `/v1/pki/ca/pem` with `failed_when: false`, report the ones that did not answer (unreachable *and* non-200, e.g. sealed), install only from those that returned 200.

Verification: both files parse, and the filter chains were exercised against synthetic probe results covering reachable (200), sealed (503) and unroutable (no `status` key) — `install -> ['up']`, `report -> ['dead', 'sealed']`, no-probe-run -> `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MpfgyV2vmFcHv8cdEmBZw