### PR TITLE
fix(release): make build-collection publishing opt-in, refresh the sthings pins

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -67,7 +67,7 @@ tasks:
 
 # PACKAGE=/tmp/ansible/collections/artifacts/sthings-baseos-25.4.1100.tar.gz task create-release
   build-collection:
-    desc: Build ansible collection
+    desc: Build ansible collection (PUBLISH=true also cuts a GitHub release)
     cmds:
       - |
         echo "CHOOSE TO BE BUILD COLLECTION:"
@@ -98,6 +98,24 @@ tasks:
         echo package ${ARTIFACT_PATH} --tag ${RELEASE_TAG}
 
         ansible-galaxy collection install $(ls {{ .OUTPUT_DIR }}/*tar.gz)
+
+        # PUBLISHING IS OPT-IN. THIS TASK USED TO ALWAYS CALL `gh release
+        # create`, SO RUNNING IT TO "JUST CHECK THE BUILD" - WHICH IS WHAT THE
+        # NAME PROMISES - PUBLISHED A REAL RELEASE, AND THE ONLY WAY TO FIND OUT
+        # WAS TO HAVE DONE IT.
+        #
+        # THE NORMAL RELEASE PATH IS main-collection-build.yaml ON MERGE TO
+        # MAIN, AND THE MANUAL RE-RELEASE PATH IS
+        # dispatch-collection-build.yml. CUTTING ONE FROM A WORKING COPY IS RARE
+        # ENOUGH TO BE WORTH TYPING OUT.
+        if [ "${PUBLISH:-false}" != "true" ]; then
+          echo
+          echo "BUILT ONLY - NOTHING PUBLISHED."
+          echo "TO CUT RELEASE ${RELEASE_TAG}: PUBLISH=true task build-collection"
+          exit 0
+        fi
+
+        echo "PUBLISHING RELEASE ${RELEASE_TAG}"
 
         dagger call --progress plain -m github.com/sagikazarmark/daggerverse/gh@main \
         release create --repo {{ .GH_REPO }} \

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -18,7 +18,17 @@ collections:
     version: 6.2.1
   - name: kubernetes.core
     version: 6.5.0
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.2.675.tar.gz/sthings-awx-26.2.675.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.2.675.tar.gz/sthings-container-26.2.675.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.2.675.tar.gz/sthings-rke-26.2.675.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.2.675.tar.gz/sthings-baseos-26.2.675.tar.gz
+  # THE sthings.* PINS. CONSUMER-FACING, AND ALSO WHAT CI INSTALLS AS THE
+  # DEPENDENCY BASELINE BEFORE OVERWRITING THE COLLECTION UNDER TEST WITH THE
+  # FRESH BUILD (see pr-collection-build.yaml, and the split explained in
+  # molecule/requirements.yaml). A stale pin here does not fail anything - it
+  # quietly tests new code against old siblings, e.g. molecule/container
+  # imports sthings.baseos.users.
+  #
+  # NB the URL shape changed: releases up to sthings-*-26.2.675 were TAGGED
+  # with a trailing `.tar.gz`, so the old links repeated it in the tag segment.
+  # Current tags do not carry it.
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.729.1166/sthings-awx-26.729.1166.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.809.1194/sthings-container-26.809.1194.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.804.1193/sthings-baseos-26.804.1193.tar.gz


### PR DESCRIPTION
Two independent footguns in the release path, found while documenting it. Neither touches a collection.

## 1. `task build-collection` published a release

The task name promises a build. It always ended by calling the daggerverse `gh` module to `release create` — so running it to *check* a build published a real GitHub release, and the only way to find out was to have done it.

Publishing is now opt-in:

```bash
task build-collection                 # builds, installs locally, prints the tag it WOULD cut
PUBLISH=true task build-collection    # builds and publishes
```

The guard fails closed — anything not exactly `true` builds only, verified including a `PUBLISH=TRUE` typo:

| `PUBLISH` | result |
|---|---|
| unset | built only |
| `false` | built only |
| `TRUE` | built only |
| `true` | publishes |

Normal releases are unaffected: they come from `main-collection-build.yaml` on merge to `main`, with `dispatch-collection-build.yml` as the manual re-release path. This task is for cutting one from a working copy, which is rare enough to be worth typing out.

## 2. The `sthings.*` pins were ~6 months stale

`requirements.yaml` pinned all four collections at `26.2.675` (February) while current is `26.809.1194`.

That file is consumer-facing **and** what CI installs as the dependency baseline before overwriting the collection under test with the fresh build (see `pr-collection-build.yaml`, and the deliberate split documented in `molecule/requirements.yaml`). A stale pin fails nothing — it quietly tests new code against old siblings. Concretely, `molecule/container/converge.yaml` does `import_playbook: sthings.baseos.users`, which was resolving to February's baseos while testing August's container.

| | was | now |
|---|---|---|
| `awx` | 26.2.675 | 26.729.1166 |
| `baseos` | 26.2.675 | 26.804.1193 |
| `container` | 26.2.675 | 26.809.1194 |
| `rke` | 26.2.675 | 26.730.1176 |

**The URL shape changed too.** Releases up to `sthings-*-26.2.675` were *tagged* with a trailing `.tar.gz`, so the old links repeated it in the tag segment — they were correct, not malformed. Current tags don't carry it, so the form is now `.../download/<tag>/<tag>.tar.gz`. All four new URLs verified to return 200.

## Testing

`Taskfile.yaml` and `requirements.yaml` both parse. The publish guard was exercised in all four cases above. `task --list` is blocked in this environment by an unrelated trust prompt on the remote `git.yaml` taskfile include, so the task was not executed end to end.

This PR touches no collection, so neither the PR build nor the merge-to-main release workflow fires — correct, since no collection content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tiUaP1AWU7GxNS166XW7b