### PR TITLE
fix(machinery): pin the proxmoxvm capability chart to 0.10.0

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -203,21 +203,19 @@ playbooks:
             # 0.4.0 on this backend (installed by hand during the live test)
             # while this file still said 0.3.0 + sops, so a playbook run used
             # to downgrade it and revert it to the embedded blob.
-            # WARNING — 0.9.2 IS TWO DIFFERENT CHARTS. The tag published to
-            # charts_oci predates stuttgart-things#2483, which added
-            # `cloneDatastore: V5010-01-1` to environments.labul WITHOUT bumping
-            # Chart.yaml. So the monorepo's 0.9.2 renders it and the registry's
-            # 0.9.2 does not, and a cluster built from here silently gets an
-            # EnvironmentConfig with no cloneDatastore — which under the
-            # DD-sthings ACL means every LabUL clone 403s unless each XR
-            # restates the field itself. kind1 has it only because it was
-            # upgraded from the local chart path.
-            # Raise this pin as soon as a corrected chart is pushed
-            # (`task push-platform-charts`); until then a run needs a follow-up
-            #   helm upgrade proxmoxvm-<env> <monorepo>/crossplane/platform/capabilities/proxmoxvm
-            # re-feeding the same --set flags. Found on u26-kind3 (2026-08-11).
+            # 0.10.0, NOT 0.9.2 — and 0.9.2 must not be reintroduced here.
+            # stuttgart-things#2483 added `cloneDatastore: V5010-01-1` to
+            # environments.labul without bumping Chart.yaml, so the registry's
+            # 0.9.2 and the monorepo's 0.9.2 became two different charts: a run
+            # against the published one silently produced an EnvironmentConfig
+            # with no cloneDatastore, and under the DD-sthings ACL every LabUL
+            # clone then 403s unless each XR restates the field. 0.10.0 is the
+            # first published version whose content matches the tree (pushed
+            # 2026-08-11 alongside this bump); 0.9.2 was deliberately left in
+            # place rather than overwritten, so clusters already on it are
+            # unchanged. Found on u26-kind3.
             - chart: proxmoxvm
-              version: "0.9.2"
+              version: "0.10.0"
               envs: "{{ proxmox_envs }}"
               credentials_prefix: proxmox-creds
               backend_key: secretStore.backend
@@ -1039,21 +1037,19 @@ playbooks:
             # 0.4.0 on this backend (installed by hand during the live test)
             # while this file still said 0.3.0 + sops, so a playbook run used
             # to downgrade it and revert it to the embedded blob.
-            # WARNING — 0.9.2 IS TWO DIFFERENT CHARTS. The tag published to
-            # charts_oci predates stuttgart-things#2483, which added
-            # `cloneDatastore: V5010-01-1` to environments.labul WITHOUT bumping
-            # Chart.yaml. So the monorepo's 0.9.2 renders it and the registry's
-            # 0.9.2 does not, and a cluster built from here silently gets an
-            # EnvironmentConfig with no cloneDatastore — which under the
-            # DD-sthings ACL means every LabUL clone 403s unless each XR
-            # restates the field itself. kind1 has it only because it was
-            # upgraded from the local chart path.
-            # Raise this pin as soon as a corrected chart is pushed
-            # (`task push-platform-charts`); until then a run needs a follow-up
-            #   helm upgrade proxmoxvm-<env> <monorepo>/crossplane/platform/capabilities/proxmoxvm
-            # re-feeding the same --set flags. Found on u26-kind3 (2026-08-11).
+            # 0.10.0, NOT 0.9.2 — and 0.9.2 must not be reintroduced here.
+            # stuttgart-things#2483 added `cloneDatastore: V5010-01-1` to
+            # environments.labul without bumping Chart.yaml, so the registry's
+            # 0.9.2 and the monorepo's 0.9.2 became two different charts: a run
+            # against the published one silently produced an EnvironmentConfig
+            # with no cloneDatastore, and under the DD-sthings ACL every LabUL
+            # clone then 403s unless each XR restates the field. 0.10.0 is the
+            # first published version whose content matches the tree (pushed
+            # 2026-08-11 alongside this bump); 0.9.2 was deliberately left in
+            # place rather than overwritten, so clusters already on it are
+            # unchanged. Found on u26-kind3.
             - chart: proxmoxvm
-              version: "0.9.2"
+              version: "0.10.0"
               envs: "{{ proxmox_envs }}"
               credentials_prefix: proxmox-creds
               backend_key: secretStore.backend


### PR DESCRIPTION
The play installed `proxmoxvm` **0.9.2** from `charts_oci`, and that tag does not contain what this repo's 0.9.2 does: stuttgart-things#2483 added `cloneDatastore: V5010-01-1` to `environments.labul` without bumping `Chart.yaml`, so the registry and the monorepo held **two different charts under one version**.

A machinery cluster built from the play therefore got a `proxmoxvm-labul` EnvironmentConfig with no `cloneDatastore` — and under the ACL that dropped `Datastore.AllocateSpace` on `/storage/DD-sthings` in early 2026-08, every LabUL clone of a template stored there 403s unless each XR restates the field itself. Both current base-OS templates (144, 211) keep their disk on that NFS store.

kind1 was unaffected only because its release had been upgraded from the local chart path by hand — nothing recorded that.

## The fix

stuttgart-things now publishes **0.10.0**, whose content matches the tree. `0.9.2` was deliberately **left in place rather than overwritten**, so clusters already on it are unchanged — which is why this is a pin bump and not a re-push.

## Verification

Against u26-kind3: the play installs `proxmoxvm-0.10.0` from OCI and the resulting EnvironmentConfig carries `cloneDatastore=V5010-01-1`. Full machinery stage re-run to `failed=0`.

Follows #1098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSYX5dsdVdzLCuB6xYhaLK
