### PR TITLE
feat(machinery): materialize terraform-credentials and packer-git-basicauth

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -262,6 +262,23 @@ playbooks:
             # encrypted manifest, so the operator materializes it as-is.
             - name: backup-registry
               namespace: crossplane-system
+            # AppRole a TofuRun authenticates to Vault with, as TF_VAR_* keys.
+            # NOT the same credential as the `vault` Secret above — a different
+            # AppRole entirely (verified by hash), which is why it needs its own
+            # blob. It was hand-applied on kind1 and existed nowhere else until
+            # stuttgart-things committed secrets/terraform-credentials.enc.yaml
+            # while retiring that cluster; without this entry a machinery
+            # cluster can render a TofuRun but not authenticate it.
+            - name: terraform-credentials
+              namespace: tekton-ci
+            # git credential the packer pipelines clone the packer repo with
+            # (.git-credentials + .gitconfig). Required now that
+            # packer_chart_enabled is on by default — the capability chart names
+            # this Secret but creates nothing, so without it a PackerBuild fails
+            # at the clone. Same token as sops-git-credentials, but the packer
+            # task consumes it in git's own file format rather than as a value.
+            - name: packer-git-basicauth
+              namespace: tekton-ci
 
           stuttgart_things_repo: "https://github.com/stuttgart-things/stuttgart-things.git"
           stuttgart_things_ref: main
@@ -1128,6 +1145,23 @@ playbooks:
             # encrypted manifest, so the operator materializes it as-is.
             - name: backup-registry
               namespace: crossplane-system
+            # AppRole a TofuRun authenticates to Vault with, as TF_VAR_* keys.
+            # NOT the same credential as the `vault` Secret above — a different
+            # AppRole entirely (verified by hash), which is why it needs its own
+            # blob. It was hand-applied on kind1 and existed nowhere else until
+            # stuttgart-things committed secrets/terraform-credentials.enc.yaml
+            # while retiring that cluster; without this entry a machinery
+            # cluster can render a TofuRun but not authenticate it.
+            - name: terraform-credentials
+              namespace: tekton-ci
+            # git credential the packer pipelines clone the packer repo with
+            # (.git-credentials + .gitconfig). Required now that
+            # packer_chart_enabled is on by default — the capability chart names
+            # this Secret but creates nothing, so without it a PackerBuild fails
+            # at the clone. Same token as sops-git-credentials, but the packer
+            # task consumes it in git's own file format rather than as a value.
+            - name: packer-git-basicauth
+              namespace: tekton-ci
 
           stuttgart_things_repo: "https://github.com/stuttgart-things/stuttgart-things.git"
           stuttgart_things_ref: main


### PR DESCRIPTION
Two Secrets a machinery cluster needs and never got. Both were hand-applied on kind1 with no source in the monorepo — they are committed there now (stuttgart-things#2484, already merged), so sops-git can fetch them.

| Secret | why it needs its own blob |
|---|---|
| `terraform-credentials` (tekton-ci) | The AppRole a **TofuRun** authenticates to Vault with, as `TF_VAR_*` keys. **Not** the same credential as the `vault` Secret already in this list — a different AppRole entirely, verified by hash. Without it a machinery cluster can render a TofuRun but not authenticate it. |
| `packer-git-basicauth` (tekton-ci) | The git credential the **packer** pipelines clone the packer repo with. The capability chart names the Secret but creates nothing, so a PackerBuild fails at the clone — which matters now that `packer_chart_enabled` defaults on (#1103 lineage). Its token is the same one as `sops-git-credentials`, but the task consumes it in git's own file format (`.git-credentials` + `.gitconfig`), so having the token does not make the Secret appear. |

## Why this ordering

The sops-git backend reads from the monorepo's `main`, so the blobs had to land there before this helps. That merge went first; this PR is the second half.

## Context

Both surfaced while auditing kind1 ahead of retiring it. A third candidate, `vault-kubeconfigs`, turned out to be byte-identical to `secrets/vault.enc.yaml` — same AppRole, just a different Secret name — and is deliberately **not** added.

Both plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSYX5dsdVdzLCuB6xYhaLK
