### PR TITLE
fix(container): default local_user to ansible_user_id in deploy_to_k8s

### DIFF
--- a/collections/container/k8s.yaml
+++ b/collections/container/k8s.yaml
@@ -7,7 +7,7 @@ playbooks:
         become: true
         vars:
           tmp_dir: "{{ '~' if ansible_user_id == 'nonroot' else '/tmp' }}"
-          local_user: "{{ ansible_user }}"
+          local_user: "{{ ansible_user | default(ansible_user_id) }}"
           become_local_user: true
 
         vars_files:


### PR DESCRIPTION
## What

The `deploy_to_k8s` play in `collections/container/k8s.yaml` set:

```yaml
local_user: "{{ ansible_user }}"
```

`ansible_user` (the connection remote_user) is **undefined** when the play runs against `localhost` with a local connection and no `remote_user` set — exactly how the nightly AWX molecule scenario invokes it via `sthings.awx.deploy` → `sthings.container.deploy_to_k8s`.

Under ansible-core's strict keyword templating, this makes every `become_user: "{{ local_user }}"` in the helm and manifests tasks fail with:

```
Error processing keyword 'become_user': 'ansible_user' is undefined
```

## Impact

This broke the `molecule/awx` `prepare` step (kind cluster + AWX deploy) on **every** run of the **Nightly Molecule AWX** workflow since it was created on 2026-07-29 — all runs have failed with this same error. The kind cluster comes up fine, then the first helm task dies during `become_user` templating.

## Fix

```yaml
local_user: "{{ ansible_user | default(ansible_user_id) }}"
```

`ansible_user_id` (the user ansible actually runs as) is the correct `become_user` for the `delegate_to: 127.0.0.1` tasks that write helm values to `tmp_dir`, and it is already used on the adjacent `tmp_dir` line. This mirrors the `ansible_user | default(...)` idiom already used elsewhere in this file and preserves existing behavior wherever `ansible_user` is defined.

## Follow-up

Once this merges and CI publishes a new `sthings-container` release, the pin in `requirements.yaml` needs bumping to the new tag so the nightly installs the fixed collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_