### PR TITLE
chore(deps): bump sthings-container pin to 26.812.1207

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -29,6 +29,6 @@ collections:
   # with a trailing `.tar.gz`, so the old links repeated it in the tag segment.
   # Current tags do not carry it.
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.729.1166/sthings-awx-26.729.1166.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.809.1194/sthings-container-26.809.1194.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.812.1207/sthings-container-26.812.1207.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.804.1193/sthings-baseos-26.804.1193.tar.gz


### PR DESCRIPTION
## What

Bumps the consumer-facing `sthings-container` pin in `requirements.yaml`:

```
sthings-container-26.809.1194  ->  sthings-container-26.812.1207
```

## Why

`26.812.1207` is the release built from #1105, which fixed `deploy_to_k8s` to default `local_user` to `ansible_user_id` when `ansible_user` is undefined.

The **Nightly Molecule AWX** workflow installs the *published* `sthings.container` from this pin (it deliberately tests what consumers install, not an unmerged build). Until this pin moves, the nightly keeps installing the broken `26.809.1194` and fails at the `prepare` step with `'ansible_user' is undefined`. This bump makes the nightly pick up the fix.

Root-cause fix: #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_