### PR TITLE
fix(awx): pin the sthings identity on the deploy_to_k8s import

### DIFF
--- a/collections/awx/deploy.yaml
+++ b/collections/awx/deploy.yaml
@@ -6,6 +6,7 @@ playbooks:
       - name: Deploy awx-operator and awx-instance on kind cluster
         import_playbook: sthings.container.deploy_to_k8s
         vars:
+          ansible_user: sthings
           profile: awx-operator-kind
           state: present
           path_to_kubeconfig: /home/{{ ansible_user }}/.kube/{{ kind_cluster_name }}


### PR DESCRIPTION
## What

Pins `ansible_user: sthings` on the `sthings.container.deploy_to_k8s` import in the AWX `deploy` playbook.

## Why

With #1105 merged, the nightly AWX molecule scenario now gets past the `become_user` templating error and progresses through kind cluster creation and helm setup — but then fails deploying the AWX-operator chart:

```
TASK [Deploy helm charts]
[ERROR]: an error occurred while trying to read the file
'/home/sthings/.kube/dev': [Errno 13] Permission denied
```

The `prepare` step builds the cluster via `sthings.container.kind`, which pins `ansible_user: sthings` and writes the kubeconfig under `/home/sthings/.kube/`. The AWX `deploy` playbook then imported `deploy_to_k8s` **without** pinning that identity, so the helm tasks ran under a different user and couldn't read the `sthings`-owned kubeconfig.

Pinning `ansible_user: sthings` on the import makes `deploy_to_k8s` run as the same identity that created the cluster (mirroring what `kind.yaml` already does), so `local_user` and `path_to_kubeconfig` resolve to the `sthings`-owned paths.

## Follow-up

Once this merges and CI publishes a new `sthings-awx` release, the `sthings-awx` pin in `requirements.yaml` needs bumping so the nightly installs the fix. Depends on: #1105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_