### PR TITLE
chore(deps): bump sthings-awx pin to 26.812.1209

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -28,7 +28,7 @@ collections:
   # NB the URL shape changed: releases up to sthings-*-26.2.675 were TAGGED
   # with a trailing `.tar.gz`, so the old links repeated it in the tag segment.
   # Current tags do not carry it.
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.729.1166/sthings-awx-26.729.1166.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.812.1209/sthings-awx-26.812.1209.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.812.1207/sthings-container-26.812.1207.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.804.1193/sthings-baseos-26.804.1193.tar.gz


### PR DESCRIPTION
## What

Bumps the consumer-facing `sthings-awx` pin in `requirements.yaml`:

```
sthings-awx-26.729.1166  ->  sthings-awx-26.812.1209
```

## Why

`26.812.1209` is the release built from #1107, which pinned `ansible_user: sthings` on the `deploy_to_k8s` import so the AWX-operator helm deploy runs as the identity that owns the kubeconfig.

The **Nightly Molecule AWX** workflow installs the *published* `sthings.awx` from this pin, so until it moves the nightly keeps running the old deploy playbook and fails with the `/home/sthings/.kube/dev` permission error. This bump makes the nightly pick up the fix.

Root-cause fix: #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_