### PR TITLE
test(awx): add temporary kubeconfig-ownership diagnostic to prepare

### DIFF
--- a/molecule/awx/prepare.yml
+++ b/molecule/awx/prepare.yml
@@ -6,6 +6,58 @@
     cluster_name: dev
     kind_cluster_name: dev
 
+- name: DIAGNOSTIC kubeconfig ownership and deploy identity (temporary)
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Login user id (no become)
+      ansible.builtin.command: id
+      changed_when: false
+      register: diag_id_login
+
+    - name: Root id (become, default become_user)
+      ansible.builtin.command: id
+      changed_when: false
+      become: true
+      register: diag_id_root
+
+    - name: Stat kubeconfig
+      ansible.builtin.stat:
+        path: /home/sthings/.kube/dev
+      become: true
+      register: diag_kc
+
+    - name: List /home, /home/sthings, /home/sthings/.kube
+      ansible.builtin.command: ls -la /home /home/sthings /home/sthings/.kube
+      changed_when: false
+      become: true
+      register: diag_ls
+      ignore_errors: true
+
+    - name: Read kubeconfig as sthings (become sthings)
+      ansible.builtin.command: head -c 1 /home/sthings/.kube/dev
+      changed_when: false
+      become: true
+      become_user: sthings
+      register: diag_read_sthings
+      ignore_errors: true
+
+    - name: Read kubeconfig as login user (no become)
+      ansible.builtin.command: head -c 1 /home/sthings/.kube/dev
+      changed_when: false
+      register: diag_read_login
+      ignore_errors: true
+
+    - name: DIAGNOSTIC RESULTS
+      ansible.builtin.debug:
+        msg:
+          - "login_user_id: {{ diag_id_login.stdout }}"
+          - "root_id:       {{ diag_id_root.stdout }}"
+          - "kubeconfig exists={{ diag_kc.stat.exists }} owner={{ diag_kc.stat.pw_name | default('?') }} group={{ diag_kc.stat.gr_name | default('?') }} mode={{ diag_kc.stat.mode | default('?') }}"
+          - "read_as_sthings rc={{ diag_read_sthings.rc | default('n/a') }} err={{ diag_read_sthings.stderr | default('') }}"
+          - "read_as_login   rc={{ diag_read_login.rc | default('n/a') }} err={{ diag_read_login.stderr | default('') }}"
+          - "ls: {{ diag_ls.stdout_lines | default(['<failed>']) }}"
+
 - name: Deploy AWX
   ansible.builtin.import_playbook: sthings.awx.deploy
   vars:


### PR DESCRIPTION
## What

Adds a **temporary, throwaway** diagnostic play to `molecule/awx/prepare.yml`, inserted right after the kind cluster is created and before the AWX deploy that fails.

## Why

After #1105 + #1107, the nightly AWX scenario still fails with:

```
kubernetes.core.helm ... trying to read the file
'/home/sthings/.kube/dev': [Errno 13] Permission denied
```

To fix it correctly we need two facts we can't see from outside CI: the kubeconfig's actual owner/group/mode, and which user the deploy tasks run as. This play prints:
- `id` for the login user and for `become: true` (root)
- `stat` of `/home/sthings/.kube/dev` (owner/group/mode)
- whether `sthings` and the login user can each read the file
- `ls -la` of `/home`, `/home/sthings`, `/home/sthings/.kube`

`molecule/` runs from the repo checkout, so this needs no collection release. **It will be reverted once the real fix is identified** — not a fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_