### PR TITLE
fix(ci): install the kubernetes python client for the AWX molecule run

### DIFF
--- a/.github/workflows/nightly-molecule-awx.yaml
+++ b/.github/workflows/nightly-molecule-awx.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           set -eu
           pip install --upgrade pip setuptools
-          pip install 'molecule' 'molecule-plugins[docker]' netaddr
+          pip install 'molecule' 'molecule-plugins[docker]' netaddr kubernetes jsonpatch
           molecule --version
         shell: bash
 


### PR DESCRIPTION
## What

Adds `kubernetes` and `jsonpatch` to the pip install in the **Nightly Molecule AWX** workflow's "Install Molecule" step.

## Why

With the kubeconfig fix (#1110), the AWX prepare now gets **past** helm — the AWX-operator chart deploys successfully — and reaches the readiness checks. Those use `kubernetes.core.k8s_info`, which fails with:

```
Failed to import the required Python library (kubernetes) on ... Python 3.14.6
Origin: helm.yaml:25 - name: Wait until pods are running
```

The step only installed `molecule`, `molecule-plugins[docker]`, and `netaddr`. The `kubernetes.core` collection needs the `kubernetes` Python client (and `jsonpatch` for k8s patch/merge operations), so add both.

Workflow-only change — no collection release needed.

## Progress so far on the AWX nightly

1. `'ansible_user' is undefined` → fixed (#1105, released `sthings-container-26.812.1207`, pin #1106)
2. identity pin (#1107, `sthings-awx-26.812.1209`, pin #1108)
3. kubeconfig permission denied → fixed (#1110, confirmed via diagnostic #1109) — helm now deploys
4. **this PR** — missing `kubernetes` python client for the readiness checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_