### PR TITLE
fix(ci): install jmespath for the AWX molecule run

### DIFF
--- a/.github/workflows/nightly-molecule-awx.yaml
+++ b/.github/workflows/nightly-molecule-awx.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           set -eu
           pip install --upgrade pip setuptools
-          pip install 'molecule' 'molecule-plugins[docker]' netaddr kubernetes jsonpatch
+          pip install 'molecule' 'molecule-plugins[docker]' netaddr kubernetes jsonpatch jmespath
           molecule --version
         shell: bash
 


### PR DESCRIPTION
## What

Adds `jmespath` to the pip install in the Nightly Molecule AWX workflow.

## Why

With `kubernetes`/`jsonpatch` added (#1111), the AWX prepare now deploys the AWX-operator chart **and** reaches the pod-readiness poll. That task's `until:` condition uses `community.general.json_query`, which fails without `jmespath`:

```
You need to install "jmespath" prior to running json_query filter
Origin: helm.yaml:34 - Wait until pods are running
```

Workflow-only change — no collection release.

## AWX nightly progress

Each fix advances the run further:
1. `ansible_user` undefined → #1105 (+ pin #1106)
2. identity pin → #1107 (+ pin #1108)
3. kubeconfig permission → #1110 (diagnostic #1109) — helm now deploys
4. `kubernetes` python client → #1111 — readiness checks import OK
5. **this PR** — `jmespath` for the `json_query` in the readiness `until:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_