### PR TITLE
test(awx): add temporary kind node-status diagnostic

### DIFF
--- a/molecule/awx/prepare.yml
+++ b/molecule/awx/prepare.yml
@@ -27,6 +27,29 @@
       ansible.builtin.set_fact:
         path_to_kubeconfig: /tmp/awx-kubeconfig
 
+    # DIAGNOSTIC (temporary): the AWX-operator pod was Unschedulable with
+    # "4 node(s) had untolerated taint(s)". Dump node readiness + taints to
+    # tell apart NotReady/no-CNI nodes from real taints or a too-short wait.
+    - name: Node readiness and taints (diagnostic)
+      ansible.builtin.command: >-
+        kubectl --kubeconfig /tmp/awx-kubeconfig get nodes
+        -o custom-columns=NAME:.metadata.name,READY:.status.conditions[?(@.type==\"Ready\")].status,TAINTS:.spec.taints
+      changed_when: false
+      register: diag_nodes
+      ignore_errors: true
+
+    - name: Node conditions detail (diagnostic)
+      ansible.builtin.command: kubectl --kubeconfig /tmp/awx-kubeconfig describe nodes
+      changed_when: false
+      register: diag_nodes_describe
+      ignore_errors: true
+
+    - name: DIAGNOSTIC node status
+      ansible.builtin.debug:
+        msg:
+          - "nodes: {{ diag_nodes.stdout_lines | default(['<failed>']) }}"
+          - "not-ready reasons: {{ diag_nodes_describe.stdout | default('') | regex_findall('KubeletNotReady[^\\n]*|container runtime network not ready[^\\n]*|cni [^\\n]*') }}"
+
 - name: Deploy AWX
   ansible.builtin.import_playbook: sthings.awx.deploy
   vars:


### PR DESCRIPTION
## What

Temporary diagnostic (like #1109) added to the staging play in `molecule/awx/prepare.yml`. To be reverted once the cause is known.

## Why

With the python deps in place (#1111, #1112), the AWX-operator chart deploys and the run reaches the pod-readiness wait — which now fails because the operator pod is **Unschedulable**:

```
0/4 nodes are available: 4 node(s) had untolerated taint(s)
```

The plain `sthings.container.kind` play (used by this scenario) relies on kind's default CNI. This diagnostic dumps node `Ready` status + taints and any `KubeletNotReady`/CNI reasons right after the cluster comes up, to distinguish:
- nodes NotReady / no CNI (→ not-ready taints on all nodes), vs
- real taints needing tolerations, vs
- a too-short pod wait.

Release-free (molecule only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_