### PR TITLE
fix(awx): install cilium CNI on the kind cluster before deploying AWX

### DIFF
--- a/molecule/awx/prepare.yml
+++ b/molecule/awx/prepare.yml
@@ -27,28 +27,19 @@
       ansible.builtin.set_fact:
         path_to_kubeconfig: /tmp/awx-kubeconfig
 
-    # DIAGNOSTIC (temporary): the AWX-operator pod was Unschedulable with
-    # "4 node(s) had untolerated taint(s)". Dump node readiness + taints to
-    # tell apart NotReady/no-CNI nodes from real taints or a too-short wait.
-    - name: Node readiness and taints (diagnostic)
-      ansible.builtin.command: >-
-        kubectl --kubeconfig /tmp/awx-kubeconfig get nodes
-        -o custom-columns=NAME:.metadata.name,READY:.status.conditions[?(@.type==\"Ready\")].status,TAINTS:.spec.taints
-      changed_when: false
-      register: diag_nodes
-      ignore_errors: true
-
-    - name: Node conditions detail (diagnostic)
-      ansible.builtin.command: kubectl --kubeconfig /tmp/awx-kubeconfig describe nodes
-      changed_when: false
-      register: diag_nodes_describe
-      ignore_errors: true
-
-    - name: DIAGNOSTIC node status
-      ansible.builtin.debug:
-        msg:
-          - "nodes: {{ diag_nodes.stdout_lines | default(['<failed>']) }}"
-          - "not-ready reasons: {{ diag_nodes_describe.stdout | default('') | regex_findall('KubeletNotReady[^\\n]*|container runtime network not ready[^\\n]*|cni [^\\n]*') }}"
+# The plain sthings.container.kind cluster is created with the default CNI
+# disabled and never installs a replacement (cilium is only wired into the
+# kind_xplane_cluster play). Without a CNI every node stays NotReady with a
+# node.kubernetes.io/not-ready:NoSchedule taint, so the awx-operator pod is
+# Unschedulable. Install cilium (the repo's kind CNI) so the nodes go Ready.
+- name: Install cilium CNI on the kind cluster
+  ansible.builtin.import_playbook: sthings.container.deploy_to_k8s
+  vars:
+    ansible_user: sthings
+    profile: cilium-kind
+    state: present
+    target_host: all
+    cluster_name: dev
 
 - name: Deploy AWX
   ansible.builtin.import_playbook: sthings.awx.deploy


### PR DESCRIPTION
## What

Removes the temporary node diagnostic (#1115) and installs cilium on the kind cluster (via `deploy_to_k8s` + the existing `cilium-kind` profile) before deploying AWX.

## Why

The diagnostic proved the root cause of the unschedulable operator pod:

```
NAME                READY   TAINTS
dev-control-plane   False   control-plane:NoSchedule, not-ready:NoSchedule
dev-worker          False   not-ready:NoSchedule
dev-worker2         False   not-ready:NoSchedule
dev-worker3         False   not-ready:NoSchedule
reason: "cni plugin not initialized"
```

All four kind nodes are **NotReady — no CNI**, so they keep the `node.kubernetes.io/not-ready:NoSchedule` taint and the awx-operator pod stays `Unschedulable` ("0/4 nodes are available: 4 node(s) had untolerated taint(s)").

The plain `sthings.container.kind` play creates the cluster with the default CNI disabled and never installs a replacement — cilium is only wired into the `kind_xplane_cluster` play. Installing cilium (the repo's standard kind CNI) makes the nodes Ready so pods can schedule.

Release-free (molecule only).

## AWX nightly progress
1. `ansible_user` undefined ✅ (#1105, released)
2. sthings identity pin ✅ (#1107, released)
3. kubeconfig permission ✅ (#1110)
4. `kubernetes` python client ✅ (#1111)
5. `jmespath` ✅ (#1112)
6. **this PR** — no CNI on the kind nodes → install cilium

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_