### PR TITLE
fix(awx): run the cilium install on localhost, not all hosts

### DIFF
--- a/molecule/awx/prepare.yml
+++ b/molecule/awx/prepare.yml
@@ -38,7 +38,7 @@
     ansible_user: sthings
     profile: cilium-kind
     state: present
-    target_host: all
+    target_host: localhost
     cluster_name: dev
 
 - name: Deploy AWX


### PR DESCRIPTION
## What

Changes the cilium install play's `target_host` from `all` to `localhost`.

## Why

The cilium install (#1117) used `target_host: all`, so `deploy_to_k8s` also targeted the molecule docker instance `ubuntu24` and tried to connect there as `ansible_user=sthings` — a user that doesn't exist in that container — failing at fact-gathering before cilium ran at all:

```
UNREACHABLE! ... unable to find user sthings: no matching entries in passwd file
```

The kind cluster and the AWX deploy are both driven from `localhost` against the staged kubeconfig, so the cilium install must be scoped to `localhost` too (matching how `sthings.awx.deploy` effectively runs). One-word fix.

Release-free (molecule only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_