### PR TITLE
fix(ci): retry collection install against transient GitHub 408/503

### DIFF
--- a/.github/workflows/nightly-molecule-awx.yaml
+++ b/.github/workflows/nightly-molecule-awx.yaml
@@ -52,7 +52,20 @@ jobs:
       - name: Install Collections
         run: |
           set -eu
-          ansible-galaxy collection install -r requirements.yaml
+          # The sthings.* pins are downloaded from GitHub release assets, which
+          # intermittently return 408/503. ansible-galaxy does not retry, so a
+          # single hiccup fails the whole run - retry with backoff.
+          for attempt in 1 2 3 4 5; do
+            if ansible-galaxy collection install -r requirements.yaml --force; then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "collection install still failing after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "collection install attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+            sleep "$((attempt * 10))"
+          done
           ansible-galaxy collection list | grep sthings
         shell: bash
 


### PR DESCRIPTION
## What

Wraps the nightly's "Install Collections" step in a 5-attempt retry loop with linear backoff.

## Why

The step downloads the `sthings.*` pins from GitHub **release assets**, which have been intermittently returning `408`/`503`. `ansible-galaxy` does not retry, so a single hiccup fails the whole run:

```
[ERROR]: Failed to download collection tar from 'default': HTTP Error 408: Request Timeout
```

The previous run got the whole prepare logic working — **cilium installs, nodes go Ready, and the run reaches the AWX-operator helm deploy** — and only died on a transient GitHub 503; this run died on a transient GitHub 408 during collection install. Retrying the install makes these flaky downloads non-fatal.

Workflow-only change — no collection release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_