### PR TITLE
fix(container): bump awx-operator chart to 3.2.1 for a live kube-rbac-proxy image

### DIFF
--- a/collections/container/helm_profiles_kind.yaml
+++ b/collections/container/helm_profiles_kind.yaml
@@ -125,7 +125,7 @@ vars:
   - name: awx-operator-kind
     file: | # pragma: allowlist secret
       ---
-      awx_operator_version: 3.0.0
+      awx_operator_version: 3.2.1
       deployment_namespace: awx
       helm_repositories:
         awx-operator:
@@ -134,7 +134,7 @@ vars:
       helm_releases:
         awx-operator:
           ref: awx-operator/awx-operator
-          version: "{{ awx_operator_version | default('3.0.0') }}"
+          version: "{{ awx_operator_version | default('3.2.1') }}"
           namespace: "{{ deployment_namespace }}"
           ignore: false
           wait: true


### PR DESCRIPTION
## What

Bumps the `awx-operator` helm chart pinned in the `awx-operator-kind` profile from `3.0.0` to `3.2.1`.

## Why

Chart `3.0.0`'s operator pod runs a `kube-rbac-proxy` sidecar from `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0`. kubebuilder **deprecated and removed** that gcr.io registry, so the sidecar now fails with `ErrImagePull` (`...:v0.15.0: not found`) and the `awx-operator-controller-manager` pod never leaves `Pending` — the `awx-manager` container is ready, only the proxy sidecar is stuck.

Confirmed in the AWX nightly (run on the current fix set): cilium installs, nodes go Ready, the awx-operator chart deploys, then the operator pod hangs on the dead sidecar image.

Chart `3.2.1` keeps the **same operator** (appVersion `2.19.1`) but moves the kube-rbac-proxy image to a live registry — a targeted fix with no AWX CRD/spec change. This profile is broken for every consumer, not just the molecule test, so the fix belongs in the collection.

## Follow-up

Once released, bump the `sthings-container` pin in `requirements.yaml` to the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_