### PR TITLE
chore(deps): bump sthings-container pin to 26.812.1215

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -29,6 +29,6 @@ collections:
   # with a trailing `.tar.gz`, so the old links repeated it in the tag segment.
   # Current tags do not carry it.
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.812.1209/sthings-awx-26.812.1209.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.812.1207/sthings-container-26.812.1207.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.812.1215/sthings-container-26.812.1215.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.804.1193/sthings-baseos-26.804.1193.tar.gz


### PR DESCRIPTION
## What

Bumps the `sthings-container` pin: `26.812.1207` → `26.812.1215`.

## Why

`26.812.1215` is the release built from #1120, which bumped the `awx-operator` chart to `3.2.1` so the operator pod's `kube-rbac-proxy` sidecar pulls a live image instead of the removed `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0`. The nightly installs the published `sthings.container` from this pin, so this makes it pick up the fix.

Root-cause fix: #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_