### PR TITLE
chore(deps): correct sthings-container pin to 26.812.1222

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -29,6 +29,6 @@ collections:
   # with a trailing `.tar.gz`, so the old links repeated it in the tag segment.
   # Current tags do not carry it.
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.812.1209/sthings-awx-26.812.1209.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.812.1215/sthings-container-26.812.1215.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.812.1222/sthings-container-26.812.1222.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.804.1193/sthings-baseos-26.804.1193.tar.gz


### PR DESCRIPTION
## What

Corrects the `sthings-container` pin: `26.812.1215` → `26.812.1222`.

## Why

The previous bump (#1121) pinned `26.812.1215`, but that release was published earlier in the day (11:41) and **predates** the awx-operator chart `3.0.0` → `3.2.1` change. The nightly consequently still deployed chart `3.0.0` and hit the removed `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0` image again (operator pod `Pending`, `ErrImagePull`).

`26.812.1222` (published 18:37, right after #1120 merged) is the release actually built from the chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_