### PR TITLE
fix(awx): resolve control_plane_ip before deploying AWX

### DIFF
--- a/molecule/awx/prepare.yml
+++ b/molecule/awx/prepare.yml
@@ -41,12 +41,23 @@
     target_host: localhost
     cluster_name: dev
 
+# The AWX CR's ingress hostname is awx-dev.<control_plane_ip>.nip.io, so the
+# deploy needs a real control_plane_ip. Nothing set it and the import below used
+# to pass control_plane_ip: "{{ control_plane_ip }}" (self-referential), which
+# tripped "Recursive loop detected in template". Resolve the kind control-plane
+# node IP into the control_plane_ip fact first, then let it flow into the deploy.
+- name: Resolve the kind control-plane IP
+  ansible.builtin.import_playbook: sthings.container.get_controlplane_ip
+  vars:
+    target_host: localhost
+    ansible_user: sthings
+    kind_cluster_name: dev
+
 - name: Deploy AWX
   ansible.builtin.import_playbook: sthings.awx.deploy
   vars:
     target_host: localhost
     cluster_name: dev
-    control_plane_ip: "{{ control_plane_ip }}"
 
 - name: Wait for all AWX components to be ready
   ansible.builtin.import_playbook: sthings.awx.check_deployment


### PR DESCRIPTION
## What

Runs `sthings.container.get_controlplane_ip` before the AWX deploy in `molecule/awx/prepare.yml`, and drops the self-referential `control_plane_ip: "{{ control_plane_ip }}"` import var.

## Why

With the operator now healthy (chart 3.2.1, #1120/#1122), a clean run got all the way to **"Create post manifests"** — where the AWX CR is built with ingress hostname `awx-dev.<control_plane_ip>.nip.io` — and failed:

```
Recursive loop detected in template: maximum recursion depth exceeded
molecule/awx/prepare.yml:49 → control_plane_ip: "{{ control_plane_ip }}"
```

Nothing ever set `control_plane_ip`, so the import var referenced itself. The repo already has a `get_controlplane_ip` play that reads the kind control-plane node's InternalIP; the AWX molecule just never ran it. Wire it in so the `control_plane_ip` fact is a concrete IP that flows into `sthings.awx.deploy`.

Release-free (molecule + an already-published collection play).

## Progress
Confirmed working this run (GitHub healthy): build → deps → kind → **cilium (nodes Ready)** → **awx-operator 3.2.1 deploys** → **operator pod Ready** → AWX CR creation. This unblocks the AWX-instance stage (postgres/web/task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbDmUJ1RPhugAjespU6bCU)_