### PR TITLE
fix(kind_machinery): cluster pin v0.3.1 -> v0.3.2, the fleet is ahead

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -486,8 +486,15 @@ playbooks:
             # NEEDS platform_rbac_manifests, applied below. Without it the build
             # runs all three ansible stages green and then wedges at the access
             # stage — see the deceptive-failure note there.
+            #
+            # v0.3.2, not v0.3.1: u26-kind3 already runs v0.3.2, and `kubectl
+            # apply` walks a Configuration BACKWARDS without complaint. A pin
+            # that trails the fleet is not a no-op on an existing cluster, it is
+            # a silent downgrade — the same failure mode CLAUDE.md records for
+            # examples/functions.yaml, here aimed at the Configuration that
+            # builds whole clusters. Check the fleet before lowering any pin.
             - name: cluster
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.1"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.2"
 
           configuration_packages: >-
             {{ machinery_packages
@@ -1488,8 +1495,15 @@ playbooks:
             # NEEDS platform_rbac_manifests, applied below. Without it the build
             # runs all three ansible stages green and then wedges at the access
             # stage — see the deceptive-failure note there.
+            #
+            # v0.3.2, not v0.3.1: u26-kind3 already runs v0.3.2, and `kubectl
+            # apply` walks a Configuration BACKWARDS without complaint. A pin
+            # that trails the fleet is not a no-op on an existing cluster, it is
+            # a silent downgrade — the same failure mode CLAUDE.md records for
+            # examples/functions.yaml, here aimed at the Configuration that
+            # builds whole clusters. Check the fleet before lowering any pin.
             - name: cluster
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.1"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.2"
 
           configuration_packages: >-
             {{ machinery_packages


### PR DESCRIPTION
Gefunden beim Abgleich der Pins gegen den laufenden Cluster, **vor** einem Play-Lauf — nicht durch den Lauf selbst: jede Task hätte Erfolg gemeldet.

## Das Problem

| Paket | auf u26-kind3 | Play-Pin (vorher) | |
|---|---|---|---|
| `platform` | v0.3.2 | v0.3.3 | Upgrade, gewollt |
| `cluster` | **v0.3.2** | **v0.3.1** | ⚠️ Downgrade |

`kubectl apply` läuft eine Configuration klaglos rückwärts. Ein Play-Lauf gegen kind3 hätte also ausgerechnet die Configuration **herabgestuft, die ganze Cluster baut** — auf einem Lauf, dessen Zweck der platform-Upgrade war.

Das ist derselbe Fehlermodus, den CLAUDE.md für `examples/functions.yaml` festhält (*„kubectl apply happily walks a Function backwards"*). Für Configuration-Pins gilt er genauso, nur prüft ihn hier nichts nach.

## Die Änderung

Pin auf v0.3.2 in beiden Playbooks, plus eine Notiz an der Stelle: **ein Pin, der hinter dem herläuft, was ein Fleet-Cluster schon fährt, ist kein No-op, sondern ein Downgrade.** Vor dem Senken eines Pins den Cluster prüfen.

Die eigene Untergrenze bleibt erfüllt: `cluster` deklariert `dependsOn platform >=v0.3.1`, gepinnt ist v0.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL