### PR TITLE
fix(kind_machinery): pins to current, and the floor trap in writing

### DIFF
--- a/collections/container/kind_machinery.yaml
+++ b/collections/container/kind_machinery.yaml
@@ -37,10 +37,17 @@
 # — cni + Flux + apps pushed onto REMOTE clusters via RemoteCluster-derived
 # ClusterProviderConfigs. Set platform_enabled=false for a pure VM builder.
 #
-# NB: the pins below must stay resolvable against each other — `platform:v0.3.3`
+# NB: the pins below must stay resolvable against each other — `platform:v0.3.8`
 # declares `dependsOn flux-init >=v0.3.0`, so bumping platform without pushing
 # the flux-init tag it wants makes the Configuration Unhealthy and the wait task
 # fails loudly (by design — a silent skip would leave a half-built cluster).
+#
+# A RAISED FLOOR DOES NOT PULL AN INSTALLED PACKAGE FORWARD. platform v0.3.8
+# requires vault-pki-secrets >=v0.1.5; on a cluster that already has v0.1.4 the
+# resolver reports `incompatible dependencies` and stops, and the dependent CR
+# has to be patched by hand. Fresh clusters never see it — they resolve the
+# newest matching version — so a floor change is only ever felt on existing
+# ones. Verified on u26-kind3, 2026-08-14.
 #
 # The corollary is a rule about what NOT to pin: a package that platform (or
 # cluster) reaches via dependsOn must not ALSO be listed in platform_packages.
@@ -453,12 +460,14 @@ playbooks:
             # cluster Configuration unresolvable and the wait task fails.
             #
             # v0.3.3 additionally declares ip-reservation, vault-auth and
-            # vault-pki-secrets (crossplane-configurations#250). Those back
+            # vault-pki-secrets (crossplane-configurations#250); v0.3.8 adds
+            # substitution discovery, the wildcard certificate, and a
+            # vault-pki-secrets floor of >=v0.1.5 — see the floor note below. Those back
             # `spec.ipReservation` / `spec.vaultIssuer` on a Platform XR, which
             # before that composed child XRs whose XRDs were on no cluster. They
             # arrive transitively — do NOT add them here, see below.
             - name: platform
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.3"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.8"
             # flux-apps is NOT listed. platform has declared the dependency
             # since v0.3.1, so an explicit pin would put the same ghcr path
             # under both a short CR name (this play) and a dependsOn — which is
@@ -494,7 +503,7 @@ playbooks:
             # examples/functions.yaml, here aimed at the Configuration that
             # builds whole clusters. Check the fleet before lowering any pin.
             - name: cluster
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.2"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.3"
 
           configuration_packages: >-
             {{ machinery_packages
@@ -1462,12 +1471,14 @@ playbooks:
             # cluster Configuration unresolvable and the wait task fails.
             #
             # v0.3.3 additionally declares ip-reservation, vault-auth and
-            # vault-pki-secrets (crossplane-configurations#250). Those back
+            # vault-pki-secrets (crossplane-configurations#250); v0.3.8 adds
+            # substitution discovery, the wildcard certificate, and a
+            # vault-pki-secrets floor of >=v0.1.5 — see the floor note below. Those back
             # `spec.ipReservation` / `spec.vaultIssuer` on a Platform XR, which
             # before that composed child XRs whose XRDs were on no cluster. They
             # arrive transitively — do NOT add them here, see below.
             - name: platform
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.3"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.8"
             # flux-apps is NOT listed. platform has declared the dependency
             # since v0.3.1, so an explicit pin would put the same ghcr path
             # under both a short CR name (this play) and a dependsOn — which is
@@ -1503,7 +1514,7 @@ playbooks:
             # examples/functions.yaml, here aimed at the Configuration that
             # builds whole clusters. Check the fleet before lowering any pin.
             - name: cluster
-              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.2"
+              package: "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.3"
 
           configuration_packages: >-
             {{ machinery_packages


### PR DESCRIPTION
Vor dem geplanten Play-Lauf gegen u26-kind3 die Pins gegen den Cluster geprüft — **zwei liefen hinterher**:

| Paket | Play | kind3 | |
|---|---|---|---|
| `platform` | v0.3.3 | **v0.3.8** | ⚠️ Downgrade um 5 Releases |
| `cluster` | v0.3.2 | **v0.3.3** | ⚠️ Downgrade |

Ein Lauf hätte beide zurückgedreht, und **jede Task hätte Erfolg gemeldet** — dieselbe stille Form wie beim `cluster`-Pin am 2026-08-13 (#1125).

Bei `platform` wären das fünf Releases: Substitutions-Entdeckung, das Wildcard-Zertifikat, die `vault-pki-secrets`-Untergrenze und die `ip-reservation`/`vault-auth`-`dependsOn` — alles auf einem Cluster, auf dem sie in aktiver Benutzung sind.

## Die Lehre ist nicht „diese zwei waren alt"

Sondern: **sie veralten bei jedem Push.** An einem Tag sind acht Paket-Versionen gewandert. Wer eine Configuration bumpt, sollte diese Datei im selben Atemzug anfassen — und wer den Play laufen lässt, vorher die Pins gegen das Ziel diffen.

## Neu dokumentiert: die Floor-Falle

Neben der bestehenden Auflösbarkeits-Notiz steht jetzt:

> **A RAISED FLOOR DOES NOT PULL AN INSTALLED PACKAGE FORWARD.**

`platform` v0.3.8 verlangt `vault-pki-secrets >=v0.1.5`. Auf einem Cluster mit v0.1.4 meldet der Resolver `incompatible dependencies` und **bleibt stehen** — er hebt das vorhandene Paket nicht an. Das abhängige CR musste von Hand gepatcht werden.

Frische Cluster sehen das nie, weil sie ohnehin die neueste passende Version auflösen. Eine Floor-Änderung wird also **ausschließlich auf bestehenden Clustern** spürbar. Verifiziert auf u26-kind3, 2026-08-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL